### PR TITLE
Improve agent-evaluation skill + add mlflow-agent dispatcher, hook, and marketplace metadata

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,0 +1,43 @@
+# MLflow Skills — Claude Code Plugin
+
+This plugin packages the MLflow Skills collection for distribution via the Anthropic Claude Code marketplace.
+
+## What's Included
+
+**9 skills** covering the full MLflow agent improvement loop:
+
+| Skill | Purpose |
+|-------|---------|
+| `mlflow-agent` | Dispatcher — recommended entry point; routes to the right skill automatically |
+| `agent-evaluation` | Set up datasets, scorers, and evaluation runs |
+| `instrumenting-with-mlflow-tracing` | Instrument Python/TypeScript code with MLflow Tracing |
+| `analyze-mlflow-trace` | Debug issues by examining spans and correlating with code |
+| `analyze-mlflow-chat-session` | Analyze multi-turn chat session traces |
+| `retrieving-mlflow-traces` | Query and filter traces from the MLflow backend |
+| `querying-mlflow-metrics` | Query token usage, latency, and quality metrics |
+| `mlflow-onboarding` | Get started with MLflow from scratch |
+| `searching-mlflow-docs` | Search MLflow documentation for answers |
+
+**1 hook:**
+
+| Hook | Purpose |
+|------|---------|
+| `hooks/mlflow-suggest-hook.py` | Auto-suggests relevant MLflow skills based on what you're working on |
+
+## Installation
+
+### Via Claude Code Marketplace (recommended)
+
+Search for "MLflow" in the Claude Code marketplace and click Install.
+
+### Manual (clone)
+
+```bash
+git clone https://github.com/mlflow/skills
+```
+
+Then add the repo path to your Claude Code settings under `Skills > Local paths`.
+
+## Full Documentation
+
+See the [main README](../README.md) for complete usage examples, skill descriptions, and configuration options.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "mlflow",
+  "displayName": "MLflow Skills",
+  "description": "Skills for tracing, evaluating, and improving AI agents with MLflow. Supports the full agent improvement loop: instrument → trace → evaluate → iterate → validate.",
+  "version": "1.0.0",
+  "author": "MLflow Team",
+  "homepage": "https://github.com/mlflow/skills",
+  "skills": [
+    "mlflow-agent",
+    "agent-evaluation",
+    "instrumenting-with-mlflow-tracing",
+    "analyze-mlflow-trace",
+    "analyze-mlflow-chat-session",
+    "retrieving-mlflow-traces",
+    "querying-mlflow-metrics",
+    "mlflow-onboarding",
+    "searching-mlflow-docs"
+  ],
+  "hooks": [
+    "hooks/mlflow-suggest-hook.py"
+  ],
+  "categories": ["observability", "evaluation", "ai-agents"],
+  "minClaudeCodeVersion": "2.0.0"
+}

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The coding agent will:
 
 ## Requirements
 
-- **MLflow 3.9+** (Instructions and code examples are tested with MLflow 3.9)
+- **MLflow 3.8+** (Instructions and code examples are tested with MLflow 3.8)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,43 @@ git submodule add https://github.com/mlflow/mlflow-skills.git .skills/mlflow
 
 ---
 
+## Auto-Suggestion Hook (Optional)
+
+The `hooks/` directory contains a `UserPromptSubmit` hook that automatically detects MLflow-related patterns in your prompts and surfaces the right skill before the agent responds — no need to remember which skill does what.
+
+### Install the Hook
+
+**Step 1:** Copy the hook somewhere permanent:
+
+```bash
+cp hooks/mlflow-suggest-hook.py ~/.claude/hooks/mlflow-suggest-hook.py
+```
+
+**Step 2:** Add it to your Claude Code settings (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "python3 ~/.claude/hooks/mlflow-suggest-hook.py"
+      }
+    ]
+  }
+}
+```
+
+**Step 3:** Start a new session. When you ask something like *"Add tracing to my app"*, you'll see:
+
+```
+💡 Use the `instrumenting-with-mlflow-tracing` skill to add MLflow tracing.
+```
+
+See [`hooks/README.md`](hooks/README.md) for the full keyword-to-skill mapping and troubleshooting.
+
+---
+
 ## Quick Examples
 
 ### Instrument Your App with Tracing

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -35,11 +35,12 @@ If you're tempted to create `evaluation/eval_dataset.py` or similar custom files
 
 **Setup (prerequisite)**: Install MLflow 3.8+, configure environment, integrate tracing
 
-**Evaluation workflow in 4 steps** (each uses MLflow APIs):
+**Evaluation workflow in 5 steps** (each uses MLflow APIs):
 
 1. **Understand**: Run agent, inspect traces, understand purpose
 2. **Scorers**: Select and register scorers for quality criteria
 3. **Dataset**: ALWAYS discover existing datasets first, only create new if needed
+3.5. **Dry Run**: Run 3 questions first — catch broken tools and misconfigured scorers before full eval
 4. **Evaluate**: Run agent on dataset, apply scorers, analyze results
 
 ## Command Conventions
@@ -334,6 +335,35 @@ dataset.merge_records(records)
 - [ ] Scorers have been registered
 - [ ] Phase A sanity check passed (pipeline runs end-to-end)
 - [ ] Phase B dataset created with 50+ questions (or existing dataset selected)
+
+### Step 3.5: Dry Run (REQUIRED before full eval)
+
+Run evaluation on **3 questions** from the dataset before committing to the full run. This catches broken tools, misconfigured scorers, and auth failures early — before they silently corrupt 100-question results.
+
+```python
+import mlflow
+
+dataset = mlflow.genai.datasets.get_dataset(name="<your-dataset-name>")
+dry_run_records = dataset.df.head(3)
+```
+
+Run `mlflow.genai.evaluate()` on these 3 records using the same wrapper and scorers as the full eval.
+
+**For each response, check:**
+
+1. **Tool calls** — Did the agent call any tools? If it called zero tools on questions that require retrieval, tools are likely broken (403s, rate limits, missing credentials).
+2. **Response quality** — Are responses empty or generic ("I don't know", "I can't help with that")? Empty responses score as irrelevant and will skew the full eval.
+3. **Scorer output** — Did all 3 scores come back as `0` or `None`? If so, the scorer is misconfigured (check return values — `"pass"`/`"fail"` are silently cast to `None`; use `"yes"`/`"no"` instead).
+
+**Decision gate:**
+
+- **If dry run shows tool failures or empty responses:** Stop. Fix the underlying issue (auth, tool config, retrieval) before proceeding. Do not run the full eval on broken infrastructure.
+- **If all 3 scorer outputs are 0 or None:** Stop. Debug scorer return values and re-register before proceeding.
+- **If dry run passes:** Report to the user: *"Dry run passed (3/3 responses non-empty, tools called, scores non-zero). Proceeding to full eval."* Then continue to Step 4.
+
+> **Why this matters:** Tool failures (403s from docs scraping, GitHub API rate limits) produce empty agent responses that score as 0. Running a 100-question eval only to discover all tools were failing wastes time and produces misleading results. The dry run catches this in under a minute.
+
+---
 
 ### Step 4: Run Evaluation
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -269,9 +269,17 @@ def wrapper(inputs):  # ❌ WRONG - inputs is NOT a dict
 2. Analyze results:
    ```bash
    # Pattern detection, failure analysis, recommendations
+   # Reads the CSV produced by mlflow.genai.evaluate() above
    uv run python scripts/analyze_results.py evaluation_results.csv
    ```
-   Generates `evaluation_report.md` with pass rates and improvement suggestions.
+   Generates `evaluation_report.md` with per-scorer pass rates and improvement suggestions.
+
+   The script reads `{scorer_name}/value` and `{scorer_name}/rationale` columns from the CSV.
+   It also accepts the legacy JSON format from `mlflow traces evaluate` for backward compatibility:
+   ```bash
+   uv run python scripts/analyze_results.py evaluation_results.json  # legacy format
+   uv run python scripts/analyze_results.py evaluation_results.csv --output my_report.md  # custom output
+   ```
 
 ## References
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -337,23 +337,43 @@ dataset.merge_records(records)
 
 ### Step 4: Run Evaluation
 
-1. Generate and run evaluation script:
+#### 4a. Estimate Runtime Before Starting
 
-   ```bash
-   # Generate evaluation script (specify module and entry point)
-   uv run python scripts/run_evaluation_template.py \
-     --module mlflow_agent.agent \
-     --entry-point run_agent
+Before launching evaluation, tell the user how long it will take:
 
-   # Review the generated script, then execute it
-   uv run python run_agent_evaluation.py
+1. **Count the dataset questions:**
+   ```python
+   import mlflow
+   dataset = mlflow.genai.datasets.get_dataset(name="<your-dataset-name>")
+   print(f"Dataset size: {len(dataset.df)} questions")
    ```
 
-   The generated script creates a wrapper function that:
-   - Accepts keyword arguments matching the dataset's input keys
-   - Provides any additional arguments the agent needs (like `llm_provider`)
-   - Runs `mlflow.genai.evaluate(data=df, predict_fn=wrapper, scorers=registered_scorers)`
-   - Saves results to `evaluation_results.csv`
+2. **Calculate the estimate** — each question runs the agent once and the judge scorer once:
+   - Opus-class judge models (e.g. `claude-opus-4`): ~45–90s per question
+   - Sonnet-class judge models (e.g. `claude-sonnet-4`): ~20–45s per question
+   - Multiple scorers per question add time proportionally
+
+   ```
+   Estimated time = N questions × 30–60s per question ÷ parallelism factor (typically 4–8x)
+   ```
+
+3. **Tell the user before starting:**
+   > "This dataset has N questions. At ~30–60s per question with typical parallelism, evaluation will take approximately **X–Y minutes**. I'll run it as a background task so you can continue working — I'll summarize the results when it's done."
+
+#### 4b. Generate the Evaluation Script
+
+```bash
+# Generate evaluation script (specify module and entry point)
+uv run python scripts/run_evaluation_template.py \
+  --module mlflow_agent.agent \
+  --entry-point run_agent
+```
+
+The generated script creates a wrapper function that:
+- Accepts keyword arguments matching the dataset's input keys
+- Provides any additional arguments the agent needs (like `llm_provider`)
+- Runs `mlflow.genai.evaluate(data=df, predict_fn=wrapper, scorers=registered_scorers)`
+- Saves results to `evaluation_results.csv`
 
 ⚠️ **CRITICAL: wrapper Signature Must Match Dataset Input Keys**
 
@@ -370,20 +390,52 @@ def wrapper(inputs):  # ❌ WRONG - inputs is NOT a dict
     return agent(inputs["query"])
 ```
 
-2. Analyze results:
-   ```bash
-   # Pattern detection, failure analysis, recommendations
-   # Reads the CSV produced by mlflow.genai.evaluate() above
-   uv run python scripts/analyze_results.py evaluation_results.csv
-   ```
-   Generates `evaluation_report.md` with per-scorer pass rates and improvement suggestions.
+#### 4c. Launch as a Background Sub-Agent
 
-   The script reads `{scorer_name}/value` and `{scorer_name}/rationale` columns from the CSV.
-   It also accepts the legacy JSON format from `mlflow traces evaluate` for backward compatibility:
-   ```bash
-   uv run python scripts/analyze_results.py evaluation_results.json  # legacy format
-   uv run python scripts/analyze_results.py evaluation_results.csv --output my_report.md  # custom output
-   ```
+Run the evaluation as a background sub-agent so the main session stays available. Use the Agent tool with `run_in_background: true`:
+
+**Sub-agent instructions (pass these verbatim):**
+```
+Run the agent evaluation and write results to scratchpad.
+
+Steps:
+1. cd <project-directory>
+2. Run: uv run python run_agent_evaluation.py
+3. When complete, write a summary to scratchpad/eval-results.md with:
+   - Exit status (success or error message)
+   - Path to results file (evaluation_results.csv)
+   - Wall-clock time taken
+4. Return only: "Evaluation complete. Results written to scratchpad/eval-results.md"
+```
+
+**In the main session, poll for completion** by checking for the scratchpad file rather than blocking:
+
+```python
+# Poll every 30s using Glob
+# Glob("scratchpad/eval-results.md")
+# When the file appears, read it and proceed to analysis
+```
+
+Do NOT use TaskOutput to wait for the background agent — that dumps the full transcript (~10–20k tokens) into the main context.
+
+#### 4d. Analyze Results (after evaluation completes)
+
+Once `scratchpad/eval-results.md` appears, run analysis:
+
+```bash
+# Pattern detection, failure analysis, recommendations
+# Reads the CSV produced by mlflow.genai.evaluate() above
+uv run python scripts/analyze_results.py evaluation_results.csv
+```
+
+Generates `evaluation_report.md` with per-scorer pass rates and improvement suggestions.
+
+The script reads `{scorer_name}/value` and `{scorer_name}/rationale` columns from the CSV.
+It also accepts the legacy JSON format from `mlflow traces evaluate` for backward compatibility:
+```bash
+uv run python scripts/analyze_results.py evaluation_results.json  # legacy format
+uv run python scripts/analyze_results.py evaluation_results.csv --output my_report.md  # custom output
+```
 
 ## References
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -222,16 +222,108 @@ If needed, create additional scorers using the `make_judge()` API. See `referenc
 3. **Ask user about existing datasets**:
 
    - "I found [N] existing evaluation dataset(s). Do you want to use one of these? (y/n)"
-   - If yes: Ask which dataset to use and record the dataset name
-   - If no: Proceed to step 4
+   - If yes: Ask which dataset to use and record the dataset name — skip to Step 4
+   - If no: Proceed to Phase A below
 
-4. **Create new dataset only if user declined existing ones**:
-   ```bash
-   # Generates dataset creation script from test cases file
-   uv run python scripts/create_dataset_template.py --test-cases-file test_cases.txt
-   uv run python scripts/create_dataset_template.py --help  # See all options
-   ```
-   Generated code uses `mlflow.genai.datasets` APIs - review and execute the script.
+**If creating a new dataset, use the two-phase approach below.**
+
+---
+
+#### Phase A: Sanity Check (5 questions — always run first)
+
+Create a minimal 5-question dataset manually from the Step 1 interview answers. The goal is to confirm the pipeline works end-to-end before investing in large-scale generation.
+
+```python
+import mlflow
+from mlflow.genai.datasets import create_dataset
+
+# Derive 5 representative questions directly from the agent's stated purpose
+# and known failure modes identified in Step 1
+sanity_records = [
+    {"inputs": {"query": "<question 1 from interview>"}, "expected_response": "<expected answer>"},
+    {"inputs": {"query": "<question 2 from interview>"}, "expected_response": "<expected answer>"},
+    # ... 5 total
+]
+
+sanity_dataset = create_dataset(
+    records=sanity_records,
+    name="sanity-check-5q",
+)
+```
+
+Run evaluation on this dataset (see Step 4), then **present results to the user** with this framing:
+
+> "This is a sanity check — 5 questions confirm the pipeline works but aren't statistically meaningful. Proceeding to Phase B to generate a proper evaluation set."
+
+Only proceed to Phase B once Phase A completes without errors.
+
+---
+
+#### Phase B: Proper Evaluation Dataset (100+ questions — run after Phase A passes)
+
+Generate questions from the agent's actual corpus rather than inventing them from scratch. The approach depends on whether the project uses Databricks or OSS MLflow.
+
+**On Databricks** — use `generate_evals_df` to synthesize questions from the agent's document corpus:
+
+```python
+from databricks.agents.evals import generate_evals_df, estimate_synthetic_num_evals
+import mlflow
+
+# agent_description comes from Step 1 interview answers
+agent_description = "<agent purpose from interview>"
+
+# docs_df: a Spark or pandas DataFrame with a "content" column containing
+# the documents/chunks the agent retrieves from (e.g., your Vector Search index)
+evals = generate_evals_df(
+    docs=docs_df,
+    num_evals=100,
+    agent_description=agent_description,
+)
+
+# Merge into MLflow dataset — don't create a separate dataset
+dataset = mlflow.genai.datasets.create_dataset(name="generated-evals-100q")
+dataset.merge_records(evals)
+```
+
+To estimate the right `num_evals` before generating:
+
+```python
+recommended = estimate_synthetic_num_evals(docs_df)
+print(f"Recommended num_evals: {recommended}")
+```
+
+**Dataset size guidance:**
+- **<30 questions**: not statistically meaningful — avoid drawing conclusions
+- **50–100 questions**: adequate for catching regressions, suitable for most agents
+- **200+ questions**: recommended when comparing model variants or scoring multiple dimensions
+
+**On OSS MLflow** — use RAGAS `TestsetGenerator` to generate from your document corpus:
+
+```python
+from ragas.testset import TestsetGenerator
+from ragas.llms import LangchainLLMWrapper
+from ragas.embeddings import LangchainEmbeddingsWrapper
+
+generator = TestsetGenerator(
+    llm=LangchainLLMWrapper(your_llm),
+    embedding_model=LangchainEmbeddingsWrapper(your_embeddings),
+)
+testset = generator.generate_with_langchain_docs(docs, testset_size=100)
+evals_df = testset.to_pandas()
+
+# Convert to MLflow dataset schema and merge
+import mlflow
+records = [
+    {"inputs": {"query": row["user_input"]}, "expected_response": row["reference"]}
+    for _, row in evals_df.iterrows()
+]
+dataset = mlflow.genai.datasets.create_dataset(name="generated-evals-100q")
+dataset.merge_records(records)
+```
+
+**If no document corpus is available** — ask the user to provide 50–100 representative queries from production logs or usage history. These are more realistic than synthetic questions and are preferable when available.
+
+---
 
 **IMPORTANT**: Do not skip dataset discovery. Always run `list_datasets.py` first, even if you plan to create a new dataset. This prevents duplicate work and ensures users are aware of existing evaluation datasets.
 
@@ -240,7 +332,8 @@ If needed, create additional scorers using the `make_judge()` API. See `referenc
 **Checkpoint - verify before proceeding:**
 
 - [ ] Scorers have been registered
-- [ ] Dataset has been created
+- [ ] Phase A sanity check passed (pipeline runs end-to-end)
+- [ ] Phase B dataset created with 50+ questions (or existing dataset selected)
 
 ### Step 4: Run Evaluation
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -223,7 +223,7 @@ If needed, create additional scorers using the `make_judge()` API. See `referenc
 3. **Ask user about existing datasets**:
 
    - "I found [N] existing evaluation dataset(s). Do you want to use one of these? (y/n)"
-   - If yes: Ask which dataset to use and record the dataset name — skip to Step 4
+   - If yes: Ask which dataset to use and record the dataset name — skip to Step 3.5
    - If no: Proceed to Phase A below
 
 **If creating a new dataset, use the two-phase approach below.**
@@ -339,6 +339,8 @@ dataset.merge_records(records)
 ### Step 3.5: Dry Run (REQUIRED before full eval)
 
 Run evaluation on **3 questions** from the dataset before committing to the full run. This catches broken tools, misconfigured scorers, and auth failures early — before they silently corrupt 100-question results.
+
+If you completed Phase A above, the pipeline is already validated — focus the dry run on scorer output only.
 
 ```python
 import mlflow

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -171,6 +171,8 @@ See `references/scorers.md` for the built-in scorers. Select any that are useful
 
 If needed, create additional scorers using the `make_judge()` API. See `references/scorers.md` on how to create custom scorers and `references/scorers-constraints.md` for best practices.
 
+> ⚠️ **CRITICAL — Scorer Return Values:** Scorers MUST instruct the LLM judge to return `"yes"` or `"no"` (or booleans/numerics). Return values of `"pass"` or `"fail"` are **silently cast to `None`** by `_cast_assessment_value_to_float` and **excluded from `results.metrics`** with no error or warning — results simply disappear. See `references/scorers-constraints.md` Constraint 2 for the full list of safe vs. broken return values.
+
 4. **REQUIRED: Register new scorers before evaluation** using Python API:
    
    ```python

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -147,12 +147,21 @@ uv run python scripts/validate_auth.py         # Test authentication before expe
 
 ## Evaluation Workflow
 
-### Step 1: Understand Agent Purpose
+### Step 1: Agent Interview (REQUIRED — do not skip)
 
-1. Invoke agent with sample input
-2. Inspect MLflow trace (especially LLM prompts describing agent purpose)
-3. Print your understanding and ask user for verification
-4. **Wait for confirmation before proceeding**
+Before doing anything else, ask the user these questions. Do NOT proceed until you have answers.
+
+**Required:**
+1. "What does your agent do? Describe its purpose in 1-2 sentences."
+2. "What are the 2-3 most important things it needs to get right?"
+3. "Are there common failure modes you've already noticed?"
+
+**Use answers to:**
+- Derive scorer names and criteria (do not invent them)
+- Write the `agent_description` parameter for `generate_evals_df`
+- Set evaluation priorities
+
+**If running in automated mode:** Read agent purpose from the codebase (SKILL.md, README, or main entry point docstring). Still surface what you found and confirm before proceeding.
 
 ### Step 2: Define Quality Scorers
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -369,6 +369,8 @@ Run `mlflow.genai.evaluate()` on these 3 records using the same wrapper and scor
 
 ### Step 4: Run Evaluation
 
+> **Large datasets (50+ questions)?** See `references/throughput-guide.md` for throughput optimization — covers parallelism env vars, async predict functions, and dataset splitting for 200+ question evals.
+
 #### 4a. Estimate Runtime Before Starting
 
 Before launching evaluation, tell the user how long it will take:
@@ -479,5 +481,6 @@ Detailed guides in `references/` (load as needed):
 - **scorers.md** - Built-in vs custom scorers, registration, testing
 - **scorers-constraints.md** - CLI requirements for custom scorers (yes/no format, templates)
 - **troubleshooting.md** - Common errors by phase with solutions
+- **throughput-guide.md** - Parallelism env vars, async predict_fn, dataset splitting for 200+ question evals
 
 Scripts are self-documenting - run with `--help` for usage details.

--- a/agent-evaluation/references/scorers-constraints.md
+++ b/agent-evaluation/references/scorers-constraints.md
@@ -64,23 +64,30 @@ Use `{{inputs}}`/`{{outputs}}` when evaluating:
 - ✅ Response relevance
 - ✅ Answer correctness
 
-## Constraint 2: Prefer "yes"/"no" Return Values for Better UI integration
+## Constraint 2: Scorers MUST Return "yes"/"no" — "pass"/"fail" Silently Drops Results
 
-⚠️ **Use "yes"/"no" NOT "pass"/"fail"**
+🚨 **CRITICAL: "pass"/"fail" return values cause SILENT DATA LOSS — use "yes"/"no" instead**
 
-**Return values that are nicely integrated with the UI:**
+### Return Values (CRITICAL)
 
-- "yes" = criteria met
-- "no" = criteria not met
+**These work correctly:**
 
-**Return values that can still work but are not shown nicely in the UI:**
+- `"yes"` / `"no"` — ✅ Required. Correctly cast to numeric scores and included in `results.metrics`.
+- `True` / `False` (boolean) — ✅ Works. Cast to 1.0 / 0.0.
+- Numeric values (e.g., `0.0`–`1.0`) — ✅ Works. Used as-is.
 
-- "pass"/"fail"
-- "true"/"false"
-- "passed"/"failed"
-- "1"/"0"
+**These cause silent data loss:**
 
-**Example - Good integration:**
+- `"pass"` / `"fail"` — ❌ BROKEN. `_cast_assessment_value_to_float` maps these to `None`, which **excludes the scorer entirely from `results.metrics`**. No error is raised — results simply disappear.
+- `"true"` / `"false"` (strings) — ❌ BROKEN. Same silent-drop behavior.
+- `"passed"` / `"failed"` — ❌ BROKEN. Same silent-drop behavior.
+- `"1"` / `"0"` (strings) — ⚠️ Unreliable. Do not use.
+
+### Why "pass"/"fail" Silently Drops Results
+
+MLflow's internal `_cast_assessment_value_to_float` function only recognizes `"yes"` and `"no"` as valid string return values. Any unrecognized string (including `"pass"` and `"fail"`) is cast to `None`. A `None` assessment value is then **excluded from aggregate metrics** — the scorer appears to run but its scores are never counted. No error or warning is emitted.
+
+**Example - Correct (results appear in metrics):**
 
 ```bash
 uv run mlflow scorers register-llm-judge \
@@ -88,17 +95,17 @@ uv run mlflow scorers register-llm-judge \
   -i "Evaluate if {{ outputs }} is high quality. Return 'yes' if high quality, 'no' if not."
 ```
 
-**Example - Still works but less nice integration:**
+**Example - BROKEN (results silently dropped from metrics):**
 
 ```bash
 uv run mlflow scorers register-llm-judge \
   -n "QualityCheck" \
-  -i "Evaluate if {{ outputs }} is high quality. Return 'pass' if good, 'fail' if bad."  # ❌ Wrong!
+  -i "Evaluate if {{ outputs }} is high quality. Return 'pass' if good, 'fail' if bad."  # ❌ Silent data loss!
 ```
 
 **Why "yes"/"no"?**
 
-MLflow's built-in judges use the binary yes/no format and the UI is optimized for this use case. 
+MLflow's built-in judges use the binary yes/no format. The internal casting logic is built around this convention — only `"yes"` and `"no"` are guaranteed to produce numeric scores that appear in `results.metrics`.
 
 ## Constraint 3: Instructions Must Include Template Variable
 
@@ -152,8 +159,8 @@ uv run mlflow scorers register-llm-judge \
 
 2. **Using "pass"/"fail" instead of "yes"/"no"**
 
-   - Result: Scorer may not work correctly with evaluation
-   - Fix: Always use "yes"/"no" format
+   - Result: `_cast_assessment_value_to_float` maps "pass"/"fail" to `None` → scorer is **silently excluded from `results.metrics`**. No error is raised.
+   - Fix: Always use `"yes"`/`"no"` (strings), booleans, or numeric values
 
 3. **Missing template variables**
 

--- a/agent-evaluation/references/throughput-guide.md
+++ b/agent-evaluation/references/throughput-guide.md
@@ -1,0 +1,167 @@
+# Evaluation Throughput Guide
+
+How to get faster results when running `mlflow.genai.evaluate()` on large datasets.
+
+## When to Think About Throughput
+
+| Dataset size | Sequential estimate | Action |
+|---|---|---|
+| <50 questions | ~5–15 min | Default settings are fine |
+| 50–200 questions | ~15–60 min | Tune `MLFLOW_GENAI_EVAL_MAX_WORKERS` |
+| 200+ questions | 1–3+ hours | Tune workers + consider dataset splitting |
+
+These are rough estimates assuming a Sonnet-class judge and one scorer per question. Opus-class judges take ~2× longer.
+
+## How MLflow Parallelizes Evaluation
+
+`mlflow.genai.evaluate()` uses background threadpools internally — it does **not** expose `max_workers` as a function parameter. Parallelism is controlled entirely via environment variables.
+
+Two levels of concurrency:
+
+```
+Data-level:   N questions run in parallel (MLFLOW_GENAI_EVAL_MAX_WORKERS)
+Scorer-level: K scorers run in parallel per question (MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS)
+```
+
+Total concurrent LLM calls ≈ `MAX_WORKERS × min(MAX_SCORER_WORKERS, num_scorers)`
+
+**Important:** `mlflow.genai.evaluate()` is **not thread-safe**. Do not call it from multiple threads in the same process. Use separate processes instead (see Dataset Splitting below).
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `MLFLOW_GENAI_EVAL_MAX_WORKERS` | 10 | Parallel data items evaluated simultaneously |
+| `MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS` | 10 | Parallel scorers per data item |
+| `MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT` | 300 | Seconds before async predict_fn times out |
+| `MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION` | (unset) | Skip the N+1 validation call if your predict_fn already generates traces |
+| `MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING` | (unset) | Set to `true` to trace scorer execution (useful for debugging, adds overhead) |
+
+### Recommended Starting Configuration
+
+```bash
+# Balanced — good for most LLM APIs with standard rate limits
+export MLFLOW_GENAI_EVAL_MAX_WORKERS=10
+export MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS=5
+
+# Skip N+1 validation call if predict_fn already produces traces (saves ~N extra LLM calls)
+export MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION=true
+```
+
+### If You're Hitting Rate Limits
+
+Reduce workers to lower total concurrent API calls:
+
+```bash
+# Conservative — for free-tier API keys or strict rate limits
+export MLFLOW_GENAI_EVAL_MAX_WORKERS=3
+export MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS=2
+# Peak concurrent calls: 3 × 2 = 6
+```
+
+### If You Have High Rate Limits
+
+```bash
+# Aggressive — for managed APIs with high rate limits (e.g., Databricks-hosted models)
+export MLFLOW_GENAI_EVAL_MAX_WORKERS=20
+export MLFLOW_GENAI_EVAL_MAX_SCORER_WORKERS=10
+```
+
+## Using Async predict_fn
+
+If your agent supports async, use an async predict function. MLflow detects it automatically and runs it more efficiently:
+
+```python
+async def predict(query: str) -> str:
+    # MLflow auto-detects async and wraps appropriately
+    return await your_agent.arun(query)
+
+results = mlflow.genai.evaluate(
+    data=dataset.df,
+    predict_fn=predict,  # async function — no changes needed to evaluate() call
+    scorers=scorers,
+)
+```
+
+Increase the timeout for slow agents:
+
+```bash
+export MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT=600  # 10 minutes
+```
+
+## Dataset Splitting (200+ Questions)
+
+For very large datasets, split into shards and run each shard in a **separate process**. Since `evaluate()` is not thread-safe, use `subprocess` or separate shell scripts — not threads.
+
+```python
+import math
+import subprocess
+import pandas as pd
+import mlflow
+
+dataset = mlflow.genai.datasets.get_dataset(name="large-eval-1000q")
+df = dataset.df
+shard_size = 100
+num_shards = math.ceil(len(df) / shard_size)
+
+# Save shards to disk for subprocess consumption
+for i in range(num_shards):
+    shard = df.iloc[i * shard_size : (i + 1) * shard_size]
+    shard.to_parquet(f"/tmp/shard_{i}.parquet")
+```
+
+Then run each shard as a separate script invocation. A shard script might look like:
+
+```python
+# run_shard.py
+import sys
+import pandas as pd
+import mlflow
+from your_agent import predict
+
+shard_path = sys.argv[1]
+df = pd.read_parquet(shard_path)
+
+scorers = [...]  # same scorers as full eval
+
+results = mlflow.genai.evaluate(
+    data=df,
+    predict_fn=predict,
+    scorers=scorers,
+)
+results.tables["eval_results"].to_csv(shard_path.replace(".parquet", "_results.csv"))
+```
+
+Run shards in parallel via background processes:
+
+```bash
+for i in $(seq 0 9); do
+  MLFLOW_GENAI_EVAL_MAX_WORKERS=10 \
+  uv run python run_shard.py /tmp/shard_${i}.parquet > /tmp/shard_${i}.log 2>&1 &
+done
+wait  # wait for all background jobs
+```
+
+Then concatenate results:
+
+```python
+import glob
+import pandas as pd
+
+all_results = pd.concat([
+    pd.read_csv(f) for f in sorted(glob.glob("/tmp/shard_*_results.csv"))
+])
+all_results.to_csv("evaluation_results_full.csv", index=False)
+```
+
+> **Note:** Each shard runs in its own process and logs independently to the same MLflow experiment. Runs will appear as separate entries — aggregate them in analysis.
+
+## Quick Wins Checklist
+
+Before running a large eval, check these:
+
+- [ ] `MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION=true` — eliminates the extra N agent calls for validation
+- [ ] `MLFLOW_GENAI_EVAL_MAX_WORKERS` set to match your API rate limit headroom
+- [ ] Judge model is Sonnet-class (not Opus) unless you need Opus quality — 2× faster
+- [ ] Scorers are registered, not inline — registered scorers run more reliably
+- [ ] Agent itself is not doing unnecessary work (extra retrieval calls, full document fetching)

--- a/agent-evaluation/scripts/analyze_results.py
+++ b/agent-evaluation/scripts/analyze_results.py
@@ -141,7 +141,7 @@ def _parse_bool_value(raw: Any) -> bool:
     if isinstance(raw, (int, float)):
         return bool(raw)
     s = str(raw).strip().lower()
-    return s in {"yes", "true", "1", "pass"}
+    return s in {"yes", "true", "1"}
 
 
 # ---------------------------------------------------------------------------

--- a/agent-evaluation/scripts/analyze_results.py
+++ b/agent-evaluation/scripts/analyze_results.py
@@ -1,126 +1,215 @@
 """
 Analyze MLflow evaluation results and generate actionable insights.
 
-This script parses the JSON output from `mlflow traces evaluate` and generates:
-- Pass rate analysis per scorer
-- Failure pattern detection (multi-failure queries)
-- Actionable recommendations
-- Markdown evaluation report (NOT HTML)
+Supports two formats:
+1. CSV output from `mlflow.genai.evaluate()` (primary format)
+   Columns: trace_id, request_id, inputs, outputs, {scorer_name}/value,
+            {scorer_name}/rationale, ...
+2. JSON output from legacy `mlflow traces evaluate` CLI (backward compat)
 
 Usage:
+    # Primary: CSV from mlflow.genai.evaluate()
+    python scripts/analyze_results.py evaluation_results.csv
+
+    # Legacy: JSON from mlflow traces evaluate
     python scripts/analyze_results.py evaluation_results.json
 
-    # Or with custom output file
-    python scripts/analyze_results.py evaluation_results.json --output report.md
+    # With custom output file
+    python scripts/analyze_results.py evaluation_results.csv --output report.md
+    python scripts/analyze_results.py evaluation_results.csv --results-path evaluation_results.csv
 """
 
+import csv
 import json
 import re
 import sys
 from collections import defaultdict
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 
-def strip_ansi_codes(text: str) -> str:
-    """Remove ANSI escape sequences from text.
+class EvaluationLoadError(Exception):
+    """Raised when an evaluation results file cannot be loaded or parsed."""
 
-    This handles color codes, cursor movement, and other terminal control sequences
-    that may appear in mlflow traces evaluate output.
 
-    Args:
-        text: Text that may contain ANSI escape sequences
+# ---------------------------------------------------------------------------
+# CSV format (mlflow.genai.evaluate output)
+# ---------------------------------------------------------------------------
+
+def load_csv_results(csv_file: str) -> dict[str, list[dict]]:
+    """Load evaluation results from CSV file produced by mlflow.genai.evaluate().
+
+    The CSV has one row per trace. Scorer columns follow the pattern:
+        {scorer_name}/value      — "yes" / "no" (or True/False variants)
+        {scorer_name}/rationale  — free-text explanation
+
+    Additional columns (trace_id, request_id, inputs, outputs, ...) are ignored
+    for scoring purposes but `inputs` is used to extract a display query string.
 
     Returns:
-        Text with all ANSI escape sequences removed
+        Dictionary mapping scorer names to list of result dicts.
+        Each result dict: {query, trace_id, passed, rationale}
     """
-    # Standard ANSI escape sequence pattern
-    # Matches: ESC [ <parameters> <command>
+    try:
+        with open(csv_file, newline="", encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            rows = list(reader)
+    except FileNotFoundError:
+        raise EvaluationLoadError(f"File not found: {csv_file}")
+
+    if not rows:
+        raise EvaluationLoadError(f"CSV file is empty: {csv_file}")
+
+    fieldnames = rows[0].keys()
+
+    # Identify scorer names from columns ending in "/value"
+    scorer_names = []
+    for col in fieldnames:
+        if col.endswith("/value"):
+            scorer_names.append(col[: -len("/value")])
+
+    if not scorer_names:
+        raise EvaluationLoadError(
+            f"No scorer columns found in CSV (expected columns like '{{scorer}}/value')."
+            f" Available columns: {list(fieldnames)}"
+        )
+
+    scorer_results: dict[str, list[dict]] = defaultdict(list)
+
+    for row in rows:
+        trace_id = row.get("trace_id", row.get("request_id", "unknown"))
+
+        # Best-effort: extract a human-readable query from the inputs column
+        query = _extract_query_from_cell(row.get("inputs", ""))
+
+        for scorer_name in scorer_names:
+            value_col = f"{scorer_name}/value"
+            rationale_col = f"{scorer_name}/rationale"
+
+            raw_value = row.get(value_col, "")
+            rationale = row.get(rationale_col, "")
+
+            # Skip rows where the scorer produced no result
+            if raw_value is None or str(raw_value).strip() == "":
+                continue
+
+            passed = _parse_bool_value(raw_value)
+
+            scorer_results[scorer_name].append(
+                {
+                    "query": query,
+                    "trace_id": trace_id,
+                    "passed": passed,
+                    "rationale": rationale,
+                }
+            )
+
+    return scorer_results
+
+
+def _extract_query_from_cell(cell_value: str) -> str:
+    """Extract a human-readable query string from an inputs cell.
+
+    The inputs column may be a JSON string like '{"query": "..."}' or
+    '{"question": "..."}', or a plain string.
+    """
+    if not cell_value:
+        return "unknown"
+    cell_str = str(cell_value).strip()
+    # Try JSON parse
+    try:
+        obj = json.loads(cell_str)
+        if isinstance(obj, dict):
+            return obj.get("query", obj.get("question", cell_str[:120]))
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return cell_str[:120]
+
+
+def _parse_bool_value(raw: Any) -> bool:
+    """Convert a scorer value cell to True (pass) / False (fail).
+
+    Handles:
+    - String "yes" / "no" (MLflow judge output)
+    - String "true" / "false"
+    - Python bool True / False
+    - Numeric 1 / 0
+    """
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    s = str(raw).strip().lower()
+    return s in {"yes", "true", "1", "pass"}
+
+
+# ---------------------------------------------------------------------------
+# JSON format (legacy mlflow traces evaluate CLI output)
+# ---------------------------------------------------------------------------
+
+def strip_ansi_codes(text: str) -> str:
+    """Remove ANSI escape sequences from text."""
     ansi_escape = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
     return ansi_escape.sub('', text)
 
 
-def load_evaluation_results(json_file: str) -> list[dict[str, Any]]:
-    """Load evaluation results from JSON file, skipping console output.
+def load_json_results(json_file: str) -> dict[str, list[dict]]:
+    """Load evaluation results from legacy JSON file (mlflow traces evaluate).
 
-    Handles mlflow traces evaluate output which contains:
-    - Lines 1-N: Console output (progress bars, warnings, logging)
-    - Line N+1: Start of JSON array '['
-    """
-    try:
-        with open(json_file) as f:
-            content = f.read()
-
-        # Strip ANSI codes before processing
-        content = strip_ansi_codes(content)
-
-        # Find the start of JSON array (skip console output)
-        json_start = content.find("[")
-        if json_start == -1:
-            print("✗ No JSON array found in file")
-            sys.exit(1)
-
-        json_content = content[json_start:]
-        data = json.loads(json_content)
-
-        if not isinstance(data, list):
-            print(f"✗ Expected JSON array, got {type(data).__name__}")
-            sys.exit(1)
-
-        return data
-
-    except FileNotFoundError:
-        print(f"✗ File not found: {json_file}")
-        sys.exit(1)
-    except json.JSONDecodeError as e:
-        print(f"✗ Invalid JSON starting at position {json_start}: {e}")
-        print(f"  First 100 chars: {json_content[:100]}")
-        sys.exit(1)
-
-
-def extract_scorer_results(data: list[dict[str, Any]]) -> dict[str, list[dict]]:
-    """Extract scorer results from assessments array structure.
-
-    Parses the actual mlflow traces evaluate structure:
+    Parses the structure:
     [{
         "trace_id": "tr-...",
+        "inputs": {"query": "..."},
         "assessments": [
-            {"name": "scorer", "result": "yes/no/pass/fail", "rationale": "...", "error": null}
+            {"name": "scorer", "result": "yes/no", "rationale": "...", "error": null}
         ]
     }]
 
     Returns:
-        Dictionary mapping scorer names to list of result dictionaries.
-        Each result dict contains: {query, trace_id, passed, rationale}
+        Dictionary mapping scorer names to list of result dicts.
     """
-    scorer_results = defaultdict(list)
+    try:
+        with open(json_file) as f:
+            content = f.read()
+    except FileNotFoundError:
+        raise EvaluationLoadError(f"File not found: {json_file}")
+
+    content = strip_ansi_codes(content)
+
+    json_start = content.find("[")
+    if json_start == -1:
+        raise EvaluationLoadError("No JSON array found in file")
+
+    json_content = content[json_start:]
+    try:
+        data = json.loads(json_content)
+    except json.JSONDecodeError as e:
+        raise EvaluationLoadError(
+            f"Invalid JSON: {e}. First 100 chars after '[': {json_content[:100]}"
+        )
+
+    if not isinstance(data, list):
+        raise EvaluationLoadError(f"Expected JSON array, got {type(data).__name__}")
+
+    scorer_results: dict[str, list[dict]] = defaultdict(list)
 
     for trace_result in data:
         trace_id = trace_result.get("trace_id", "unknown")
-
-        # Extract query from inputs if available
         inputs = trace_result.get("inputs", {})
         query = inputs.get("query", inputs.get("question", "unknown"))
 
-        # Parse assessments array
-        assessments = trace_result.get("assessments", [])
-
-        for assessment in assessments:
+        for assessment in trace_result.get("assessments", []):
             scorer_name = assessment.get("name", "unknown")
             result = assessment.get("result", "fail")
-            result_str = result.lower() if result else "fail"
             rationale = assessment.get("rationale", "")
             error = assessment.get("error")
 
-            # Map string results to boolean
-            # "yes" / "pass" → True
-            # "no" / "fail" → False
-            passed = result_str in ["yes", "pass"]
-
-            # Skip if there was an error
             if error:
                 print(f"  ⚠ Warning: Scorer {scorer_name} had error for trace {trace_id}: {error}")
                 continue
+
+            passed = _parse_bool_value(result)
 
             scorer_results[scorer_name].append(
                 {"query": query, "trace_id": trace_id, "passed": passed, "rationale": rationale}
@@ -129,11 +218,44 @@ def extract_scorer_results(data: list[dict[str, Any]]) -> dict[str, list[dict]]:
     return scorer_results
 
 
+# ---------------------------------------------------------------------------
+# Format detection
+# ---------------------------------------------------------------------------
+
+def load_evaluation_results(input_file: str) -> dict[str, list[dict]]:
+    """Detect file format and load results accordingly.
+
+    Detection logic:
+    - `.csv` extension → CSV format (mlflow.genai.evaluate)
+    - `.json` extension → legacy JSON format
+    - Unknown extension → try CSV first, fall back to JSON
+    """
+    suffix = Path(input_file).suffix.lower()
+    if suffix == ".csv":
+        return load_csv_results(input_file)
+    elif suffix == ".json":
+        return load_json_results(input_file)
+    else:
+        # Try CSV first (preferred modern format); if it fails, try JSON.
+        # If both fail, raise the original CSV error so the message is meaningful.
+        try:
+            return load_csv_results(input_file)
+        except EvaluationLoadError as csv_err:
+            try:
+                return load_json_results(input_file)
+            except EvaluationLoadError:
+                raise csv_err
+
+
+# ---------------------------------------------------------------------------
+# Analysis
+# ---------------------------------------------------------------------------
+
 def calculate_pass_rates(scorer_results: dict[str, list[dict]]) -> dict[str, dict]:
     """Calculate pass rates for each scorer.
 
     Returns:
-        Dictionary mapping scorer names to {pass_rate, passed, total, grade}
+        Dictionary mapping scorer names to {pass_rate, passed, total, grade, emoji}
     """
     pass_rates = {}
 
@@ -142,22 +264,16 @@ def calculate_pass_rates(scorer_results: dict[str, list[dict]]) -> dict[str, dic
         passed = sum(1 for r in results if r["passed"])
         pass_rate = (passed / total * 100) if total > 0 else 0
 
-        # Assign grade
         if pass_rate >= 90:
-            grade = "A"
-            emoji = "✓✓"
+            grade, emoji = "A", "✓✓"
         elif pass_rate >= 80:
-            grade = "B"
-            emoji = "✓"
+            grade, emoji = "B", "✓"
         elif pass_rate >= 70:
-            grade = "C"
-            emoji = "⚠"
+            grade, emoji = "C", "⚠"
         elif pass_rate >= 60:
-            grade = "D"
-            emoji = "⚠⚠"
+            grade, emoji = "D", "⚠⚠"
         else:
-            grade = "F"
-            emoji = "✗"
+            grade, emoji = "F", "✗"
 
         pass_rates[scorer_name] = {
             "pass_rate": pass_rate,
@@ -174,12 +290,10 @@ def detect_failure_patterns(scorer_results: dict[str, list[dict]]) -> list[dict]
     """Detect patterns in failed queries.
 
     Returns:
-        List of pattern dictionaries with {name, queries, scorers, description}
+        List of pattern dicts: {name, queries, priority, description}
     """
     patterns = []
-
-    # Collect all failures
-    failures_by_query = defaultdict(list)
+    failures_by_query: dict[str, list[dict]] = defaultdict(list)
 
     for scorer_name, results in scorer_results.items():
         for result in results:
@@ -192,19 +306,18 @@ def detect_failure_patterns(scorer_results: dict[str, list[dict]]) -> list[dict]
                     }
                 )
 
-    # Pattern: Multi-failure queries (queries failing 3+ scorers)
-    multi_failures = []
-    for query, failures in failures_by_query.items():
-        if len(failures) >= 3:
-            multi_failures.append(
-                {"query": query, "scorers": [f["scorer"] for f in failures], "count": len(failures)}
-            )
+    # Multi-failure queries: failing 3+ scorers
+    multi_failures = [
+        {"query": q, "scorers": [f["scorer"] for f in failures], "count": len(failures)}
+        for q, failures in failures_by_query.items()
+        if len(failures) >= 3
+    ]
 
     if multi_failures:
         patterns.append(
             {
                 "name": "Multi-Failure Queries",
-                "description": "Queries failing 3 or more scorers - need comprehensive fixes",
+                "description": "Queries failing 3 or more scorers — need comprehensive fixes",
                 "queries": multi_failures,
                 "priority": "CRITICAL",
             }
@@ -213,15 +326,12 @@ def detect_failure_patterns(scorer_results: dict[str, list[dict]]) -> list[dict]
     return patterns
 
 
-def generate_recommendations(pass_rates: dict[str, dict], patterns: list[dict]) -> list[dict]:
-    """Generate actionable recommendations based on analysis.
-
-    Returns:
-        List of recommendation dictionaries with {title, issue, impact, effort, priority}
-    """
+def generate_recommendations(
+    pass_rates: dict[str, dict], patterns: list[dict]
+) -> list[dict]:
+    """Generate actionable recommendations based on analysis."""
     recommendations = []
 
-    # Recommendations from low-performing scorers
     for scorer_name, metrics in pass_rates.items():
         if metrics["pass_rate"] < 80:
             recommendations.append(
@@ -234,7 +344,6 @@ def generate_recommendations(pass_rates: dict[str, dict], patterns: list[dict]) 
                 }
             )
 
-    # Recommendations from patterns
     for pattern in patterns:
         if pattern["priority"] == "CRITICAL":
             recommendations.append(
@@ -257,12 +366,15 @@ def generate_recommendations(pass_rates: dict[str, dict], patterns: list[dict]) 
                 }
             )
 
-    # Sort by priority
     priority_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
     recommendations.sort(key=lambda x: priority_order.get(x["priority"], 99))
 
     return recommendations
 
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
 
 def generate_report(
     scorer_results: dict[str, list[dict]],
@@ -272,11 +384,10 @@ def generate_report(
     output_file: str,
 ) -> None:
     """Generate markdown evaluation report."""
-
-    total_queries = len(next(iter(scorer_results.values()))) if scorer_results else 0
+    total_queries = max(len(v) for v in scorer_results.values()) if scorer_results else 0
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-    report_lines = [
+    lines = [
         "# Agent Evaluation Results Analysis",
         "",
         f"**Generated**: {timestamp}",
@@ -287,28 +398,24 @@ def generate_report(
         "",
     ]
 
-    # Pass rates table
     for scorer_name, metrics in pass_rates.items():
-        emoji = metrics["emoji"]
-        report_lines.append(
-            f"  {scorer_name:30} {metrics['pass_rate']:5.1f}% ({metrics['passed']}/{metrics['total']}) {emoji}"
+        lines.append(
+            f"  {scorer_name:30} {metrics['pass_rate']:5.1f}%"
+            f" ({metrics['passed']}/{metrics['total']}) {metrics['emoji']}"
         )
 
-    report_lines.extend(["", ""])
+    lines.extend(["", ""])
 
-    # Average pass rate
     avg_pass_rate = (
         sum(m["pass_rate"] for m in pass_rates.values()) / len(pass_rates) if pass_rates else 0
     )
-    report_lines.append(f"**Average Pass Rate**: {avg_pass_rate:.1f}%")
-    report_lines.extend(["", ""])
+    lines.append(f"**Average Pass Rate**: {avg_pass_rate:.1f}%")
+    lines.extend(["", ""])
 
-    # Failure patterns
     if patterns:
-        report_lines.extend(["## Failure Patterns Detected", ""])
-
+        lines.extend(["## Failure Patterns Detected", ""])
         for i, pattern in enumerate(patterns, 1):
-            report_lines.extend(
+            lines.extend(
                 [
                     f"### {i}. {pattern['name']} [{pattern['priority']}]",
                     "",
@@ -318,26 +425,22 @@ def generate_report(
                     "",
                 ]
             )
-
-            for query_info in pattern["queries"][:5]:  # Show first 5
-                report_lines.append(
-                    f'- **Query**: "{query_info["query"][:100]}{"..." if len(query_info["query"]) > 100 else ""}"'
+            for query_info in pattern["queries"][:5]:
+                q = query_info["query"]
+                lines.append(
+                    f'- **Query**: "{q[:100]}{"..." if len(q) > 100 else ""}"'
                 )
-                report_lines.append(f"  - Failed scorers: {', '.join(query_info['scorers'])}")
-                report_lines.append("")
-
+                lines.append(f"  - Failed scorers: {', '.join(query_info['scorers'])}")
+                lines.append("")
             if len(pattern["queries"]) > 5:
-                report_lines.append(f"  _(+{len(pattern['queries']) - 5} more queries)_")
-                report_lines.append("")
+                lines.append(f"  _(+{len(pattern['queries']) - 5} more queries)_")
+                lines.append("")
+            lines.append("")
 
-            report_lines.append("")
-
-    # Recommendations
     if recommendations:
-        report_lines.extend(["## Recommendations", ""])
-
+        lines.extend(["## Recommendations", ""])
         for i, rec in enumerate(recommendations, 1):
-            report_lines.extend(
+            lines.extend(
                 [
                     f"### {i}. {rec['title']} [{rec['priority']}]",
                     "",
@@ -348,8 +451,7 @@ def generate_report(
                 ]
             )
 
-    # Next steps
-    report_lines.extend(
+    lines.extend(
         [
             "## Next Steps",
             "",
@@ -366,14 +468,17 @@ def generate_report(
         ]
     )
 
-    # Write report
     with open(output_file, "w") as f:
-        f.write("\n".join(report_lines))
+        f.write("\n".join(lines))
 
     print(f"\n✓ Report saved to: {output_file}")
 
 
-def main():
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
     """Main analysis workflow."""
     print("=" * 60)
     print("MLflow Evaluation Results Analysis")
@@ -381,36 +486,54 @@ def main():
     print()
 
     # Parse arguments
-    if len(sys.argv) < 2:
+    # Supports both positional and --results-path for the input file
+    args = sys.argv[1:]
+    if not args:
         print(
-            "Usage: python scripts/analyze_results.py <evaluation_results.json> [--output report.md]"
+            "Usage: python scripts/analyze_results.py <evaluation_results.csv> [--output report.md]"
         )
+        print("       python scripts/analyze_results.py --results-path evaluation_results.csv")
         sys.exit(1)
 
-    json_file = sys.argv[1]
+    input_file = None
     output_file = "evaluation_report.md"
 
-    if "--output" in sys.argv:
-        idx = sys.argv.index("--output")
-        if idx + 1 < len(sys.argv):
-            output_file = sys.argv[idx + 1]
+    i = 0
+    while i < len(args):
+        if args[i] == "--output" and i + 1 < len(args):
+            output_file = args[i + 1]
+            i += 2
+        elif args[i] == "--results-path" and i + 1 < len(args):
+            input_file = args[i + 1]
+            i += 2
+        elif not args[i].startswith("--"):
+            input_file = args[i]
+            i += 1
+        else:
+            i += 1
 
-    # Load results
-    print(f"Loading evaluation results from: {json_file}")
-    data = load_evaluation_results(json_file)
-    print("✓ Results loaded")
-    print()
-
-    # Extract scorer results
-    print("Extracting scorer results...")
-    scorer_results = extract_scorer_results(data)
-
-    if not scorer_results:
-        print("✗ No scorer results found in JSON")
-        print("  Check that the JSON file contains evaluation results")
+    if input_file is None:
+        print("✗ No input file specified")
         sys.exit(1)
 
-    print(f"✓ Found {len(scorer_results)} scorer(s)")
+    # Detect format and load
+    suffix = Path(input_file).suffix.lower()
+    fmt = "CSV (mlflow.genai.evaluate)" if suffix == ".csv" else (
+        "JSON (legacy mlflow traces evaluate)" if suffix == ".json" else "auto-detect"
+    )
+    print(f"Loading evaluation results from: {input_file}")
+    print(f"Format: {fmt}")
+    try:
+        scorer_results = load_evaluation_results(input_file)
+    except EvaluationLoadError as e:
+        print(f"✗ {e}")
+        sys.exit(1)
+
+    if not scorer_results:
+        print("✗ No scorer results found")
+        sys.exit(1)
+
+    print(f"✓ Loaded results for {len(scorer_results)} scorer(s)")
     print()
 
     # Calculate pass rates
@@ -419,9 +542,9 @@ def main():
 
     print("\nOverall Pass Rates:")
     for scorer_name, metrics in pass_rates.items():
-        emoji = metrics["emoji"]
         print(
-            f"  {scorer_name:30} {metrics['pass_rate']:5.1f}% ({metrics['passed']}/{metrics['total']}) {emoji}"
+            f"  {scorer_name:30} {metrics['pass_rate']:5.1f}%"
+            f" ({metrics['passed']}/{metrics['total']}) {metrics['emoji']}"
         )
     print()
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,70 @@
+# MLflow Skills Hooks
+
+Hooks extend your coding agent with automatic skill suggestions based on what you're asking about.
+
+## `mlflow-suggest-hook.py`
+
+A `UserPromptSubmit` hook that detects MLflow-related patterns in your prompts and suggests the most relevant skill before the agent responds. This removes the need to know which skill to invoke — the agent surfaces the right one automatically.
+
+### What It Detects
+
+| Keywords in your prompt | Suggested skill |
+|-------------------------|----------------|
+| trace, tracing, autolog, span, instrument | `instrumenting-with-mlflow-tracing` |
+| evaluat, scorer, judge, dataset, assess, improve quality | `agent-evaluation` |
+| trace id, debug trace, why did, what went wrong, analyze trace | `analyze-mlflow-trace` |
+| session, conversation, chat history, multi-turn | `analyze-mlflow-chat-session` |
+| search traces, find traces, filter traces, get trace | `retrieving-mlflow-traces` |
+| metrics, token usage, latency, cost, usage trend | `querying-mlflow-metrics` |
+| get started, set up mlflow, onboard, quickstart | `mlflow-onboarding` |
+| mlflow docs, mlflow api, how to use mlflow | `searching-mlflow-docs` |
+
+Multiple suggestions can fire in a single prompt if multiple patterns match.
+
+### Installation
+
+**Step 1: Copy the hook to a permanent location**
+
+```bash
+# Option A: copy into your home skills directory
+cp hooks/mlflow-suggest-hook.py ~/.claude/hooks/mlflow-suggest-hook.py
+
+# Option B: use an absolute path to the hook in-place (see Step 2)
+```
+
+**Step 2: Register the hook in your Claude Code settings**
+
+Add the following to your `~/.claude/settings.json` (global) or `.claude/settings.json` (project-level):
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "python3 /path/to/hooks/mlflow-suggest-hook.py"
+      }
+    ]
+  }
+}
+```
+
+Replace `/path/to/hooks/mlflow-suggest-hook.py` with the absolute path where you placed the file.
+
+**Step 3: Verify**
+
+Start a new Claude Code session and type a prompt containing `tracing` or `evaluate`. You should see a suggestion like:
+
+```
+💡 Use the `instrumenting-with-mlflow-tracing` skill to add MLflow tracing.
+```
+
+### How It Works
+
+Claude Code calls `UserPromptSubmit` hooks before passing your prompt to the model. This hook reads the prompt from stdin as JSON (`{"prompt": "..."}`), performs keyword matching, and prints suggestions to stdout. Claude Code displays these suggestions to you before the agent responds.
+
+The hook exits cleanly with no output when no MLflow patterns are detected, so it has zero impact on non-MLflow conversations.
+
+### Compatibility
+
+This hook works with any coding agent that supports the `UserPromptSubmit` hook protocol, including Claude Code. Other agents may use different hook registration mechanisms — check your agent's documentation for the equivalent setting.

--- a/hooks/mlflow-suggest-hook.py
+++ b/hooks/mlflow-suggest-hook.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""UserPromptSubmit hook: detects MLflow usage and suggests relevant skill."""
+import json
+import sys
+import re
+
+def main():
+    data = json.load(sys.stdin)
+    prompt = data.get("prompt", "").lower()
+
+    suggestions = []
+
+    if any(k in prompt for k in ["trace", "tracing", "autolog", "span", "instrument"]):
+        suggestions.append("💡 Use the `instrumenting-with-mlflow-tracing` skill to add MLflow tracing.")
+
+    if any(k in prompt for k in ["evaluat", "scorer", "judge", "dataset", "assess", "improve quality"]):
+        suggestions.append("💡 Use the `agent-evaluation` skill to evaluate your agent with MLflow.")
+
+    if any(k in prompt for k in ["trace id", "debug trace", "why did", "what went wrong", "analyze trace"]):
+        suggestions.append("💡 Use the `analyze-mlflow-trace` skill to debug this trace.")
+
+    if any(k in prompt for k in ["session", "conversation", "chat history", "multi-turn"]):
+        suggestions.append("💡 Use the `analyze-mlflow-chat-session` skill to analyze chat sessions.")
+
+    if any(k in prompt for k in ["search traces", "find traces", "filter traces", "get trace"]):
+        suggestions.append("💡 Use the `retrieving-mlflow-traces` skill to search/filter traces.")
+
+    if any(k in prompt for k in ["metrics", "token usage", "latency", "cost", "usage trend"]):
+        suggestions.append("💡 Use the `querying-mlflow-metrics` skill to fetch aggregated metrics.")
+
+    if any(k in prompt for k in ["get started", "set up mlflow", "onboard", "quickstart"]):
+        suggestions.append("💡 Use the `mlflow-onboarding` skill to get started with MLflow.")
+
+    if any(k in prompt for k in ["mlflow docs", "mlflow api", "how to use mlflow"]):
+        suggestions.append("💡 Use the `searching-mlflow-docs` skill to search MLflow documentation.")
+
+    if suggestions:
+        print("\n".join(suggestions))
+
+if __name__ == "__main__":
+    main()

--- a/hooks/mlflow-suggest-hook.py
+++ b/hooks/mlflow-suggest-hook.py
@@ -5,7 +5,10 @@ import sys
 import re
 
 def main():
-    data = json.load(sys.stdin)
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
     prompt = data.get("prompt", "").lower()
 
     suggestions = []

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -80,6 +80,8 @@ Check these in order:
 - **Wrong experiment ID** — verify the experiment ID passed to `search_traces()` matches the experiment active when the code ran (`mlflow.get_experiment_by_name(...)` to confirm).
 - **Network/auth issues** — can the process reach the tracking server? Check for connection errors or 401/403 responses in logs.
 
+For automated validation, use `agent-evaluation/scripts/validate_tracing_runtime.py`.
+
 ---
 
 ## Feedback Collection

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -59,7 +59,26 @@ print(f"Found {len(traces)} trace(s)")
 assert len(traces) > 0, "No traces were logged — check tracking URI and experiment settings"
 ```
 
-3. **Report the result** — tell the user how many traces were found and confirm tracing is working
+3. **Verify spans were captured** — confirm the trace contains the expected spans, not just an empty shell:
+
+```python
+trace = traces.iloc[0]
+spans = mlflow.get_trace(trace.trace_id).data.spans
+print(f"Trace has {len(spans)} span(s)")
+for span in spans:
+    print(f"  - {span.name} ({span.span_type})")
+```
+
+4. **Report the result** — tell the user how many traces and spans were found and confirm tracing is working
+
+### If no traces appear
+
+Check these in order:
+
+- **Tracking URI not set** — is `mlflow.set_tracking_uri(...)` called before the agent run? Without this, traces go to a local `./mlruns` directory instead of the configured server.
+- **Autolog warnings** — did `mlflow.autolog()` or framework-specific `mlflow.<framework>.autolog()` raise any warnings during setup? Check stderr for patching failures.
+- **Wrong experiment ID** — verify the experiment ID passed to `search_traces()` matches the experiment active when the code ran (`mlflow.get_experiment_by_name(...)` to confirm).
+- **Network/auth issues** — can the process reach the tracking server? Check for connection errors or 401/403 responses in logs.
 
 ---
 

--- a/mlflow-agent/SKILL.md
+++ b/mlflow-agent/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: mlflow-agent
+description: >
+  Master dispatcher for all MLflow workflows. Use this skill when the user wants to do
+  anything with MLflow — tracing, evaluating, debugging, or improving an agent.
+  Routes to the right MLflow sub-skill automatically.
+  Triggers on: "use mlflow", "help with mlflow", "mlflow agent", "add mlflow to my project",
+  "trace my agent", "evaluate my agent", or any MLflow task without a specific skill in mind.
+disable-model-invocation: true
+---
+
+# MLflow Agent
+
+Master dispatcher for MLflow workflows. Reads user intent and invokes the right sub-skill.
+
+## Trigger
+
+Use when the user wants to do anything with MLflow but hasn't specified which skill to use.
+
+## Process
+
+1. Read the user's request and identify intent
+2. Map to the appropriate skill:
+   - Tracing / instrumentation → `instrumenting-with-mlflow-tracing`
+   - Evaluation / scoring → `agent-evaluation`
+   - Debug a trace → `analyze-mlflow-trace`
+   - Debug a chat session → `analyze-mlflow-chat-session`
+   - Search traces → `retrieving-mlflow-traces`
+   - Metrics / costs → `querying-mlflow-metrics`
+   - Getting started → `mlflow-onboarding`
+   - Docs / API questions → `searching-mlflow-docs`
+3. If intent is unclear, ask ONE clarifying question, then dispatch
+4. Invoke the matched skill using the Skill tool
+
+## Key Rules
+
+- Never do the work yourself — always dispatch to the appropriate sub-skill
+- One clarifying question maximum before dispatching
+- If the user says "evaluate AND trace", dispatch tracing first, then evaluation
+- If the user's request spans multiple skills, handle them in logical order (setup → instrument → evaluate)

--- a/tests/infra.py
+++ b/tests/infra.py
@@ -93,7 +93,7 @@ def start_mlflow_server(config: TestConfig, state: RuntimeState) -> bool:
     with open(log_file, "w") as f:
         process = subprocess.Popen(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "mlflow",
                 "server",
@@ -262,7 +262,7 @@ def run_setup_script(config: TestConfig, state: RuntimeState) -> bool:
 
     try:
         run_command(
-            ["python", str(setup_script)],
+            [sys.executable, str(setup_script)],
             cwd=state.work_dir,
             env=env,
         )
@@ -304,6 +304,8 @@ def setup_claude_code_tracing(config: TestConfig, state: RuntimeState) -> bool:
 
     try:
         cmd = [
+            sys.executable,
+            "-m",
             "mlflow",
             "autolog",
             "claude",
@@ -315,6 +317,30 @@ def setup_claude_code_tracing(config: TestConfig, state: RuntimeState) -> bool:
         ]
         run_command(cmd, cwd=state.full_project_dir)
         log.info("MLflow autolog configured for Claude Code")
+
+        # Patch installed stop-hook to use the current Python interpreter.
+        # mlflow writes either "mlflow autolog claude stop-hook" or
+        # 'python -c "from mlflow.claude_code.hooks import ..."' to
+        # settings.json. The bare "mlflow" / "python" commands may point to a
+        # different Python (e.g., system Python 3.9 vs test Python 3.10+),
+        # or "python" may not exist at all on macOS. Replace with full path.
+        settings_path = state.full_project_dir / ".claude" / "settings.json"
+        if settings_path.exists():
+            import json as _json
+            with open(settings_path) as f:
+                settings_str = f.read()
+            patched = settings_str
+            # Old format: "mlflow autolog ..."
+            patched = patched.replace(
+                '"mlflow autolog', f'"{sys.executable} -m mlflow autolog'
+            )
+            # New format: 'python -c "..."'
+            patched = patched.replace('"python -c ', f'"{sys.executable} -c ')
+            if patched != settings_str:
+                with open(settings_path, "w") as f:
+                    f.write(patched)
+                log.info(f"Patched stop-hook to use {sys.executable}")
+
     except subprocess.CalledProcessError as e:
         log.error(f"Failed to configure Claude Code tracing: {e}")
         return False

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -130,7 +130,7 @@ def verify_judges(config: TestConfig, state: RuntimeState) -> bool:
 
     try:
         result = run_command(
-            ["python", run_judges_script],
+            [sys.executable, run_judges_script],
             cwd=state.full_project_dir,
             check=False,
             timeout=config.verification_timeout,


### PR DESCRIPTION
## Summary

Improvements to the `agent-evaluation` skill and supporting infrastructure based on friction points discovered in the [Claude Code agent improvement loop CUJ](https://github.com/mlflow/skills/issues/new). These changes address the most common failure modes when using the skill end-to-end.

### agent-evaluation skill (P0 fixes)
- **Fix `analyze_results.py`** — rewritten to parse CSV output from `mlflow.genai.evaluate()` (with backward compat for old JSON format)
- **Enforce `"yes"`/`"no"` scorer return values** — `"pass"`/`"fail"` are silently cast to `None` by `_cast_assessment_value_to_float` and excluded from `results.metrics`. Strengthened from "prefer" to CRITICAL requirement with technical explanation.
- **Blocking user interview gate** — Step 1 is now a structured 3-question interview that can't be bypassed in automated mode
- **Two-phase dataset approach** — Phase A (5-question sanity check) → Phase B (`generate_evals_df` for Databricks, RAGAS for OSS)
- **Background sub-agent evaluation** — time estimation + launch via Agent tool with `run_in_background: true`
- **3-question dry run** — mandatory gate that catches tool failures (403s, rate limits) before committing to full eval

### New capabilities
- **`mlflow-agent` dispatcher skill** — single entry point that routes user intent to the right MLflow sub-skill
- **UserPromptSubmit hook** — auto-suggests relevant skills based on prompt keywords
- **`.claude-plugin/plugin.json`** — marketplace metadata for Anthropic submission

### instrumenting-with-mlflow-tracing
- **Enhanced runtime verification** — span-level checks + troubleshooting guide

## Test plan

- [ ] Run `agent-evaluation` skill end-to-end on a sample agent — verify interview gate, Phase A sanity check, dry run, and full eval all execute in order
- [ ] Run `analyze_results.py` on a CSV output from `mlflow.genai.evaluate()` — verify pass rates and report generation
- [ ] Run `analyze_results.py` on legacy JSON output — verify backward compat
- [ ] Test `mlflow-agent` dispatcher routes correctly for each intent type
- [ ] Test `mlflow-suggest-hook.py` with sample prompts containing MLflow keywords
- [ ] Verify `plugin.json` skills list matches actual skill directories

Co-authored-by: Claude <noreply@anthropic.com>