### PR TITLE
feat: Add Gemini/Google provider support across MLflow skills

### DIFF
--- a/agent-evaluation/references/scorers.md
+++ b/agent-evaluation/references/scorers.md
@@ -88,6 +88,7 @@ MLflow uses the format `<provider>:/<model-name>`. Examples:
 | `databricks:/<endpoint>` | Databricks serving endpoint |
 | `openai:/<model>` | OpenAI (e.g., `openai:/gpt-4`) |
 | `anthropic:/<model>` | Anthropic |
+| `gemini:/<model>` | Google Gemini (e.g., `gemini:/gemini-2.5-flash`) |
 
 #### Reusing the Agent's LLM
 

--- a/agent-evaluation/references/troubleshooting.md
+++ b/agent-evaluation/references/troubleshooting.md
@@ -575,6 +575,7 @@ def predict_fn(messages):
    ```bash
    export OPENAI_API_KEY="sk-..."
    export ANTHROPIC_API_KEY="sk-ant-..."
+   export GEMINI_API_KEY="..."       # Google Gemini (also accepted: GOOGLE_API_KEY)
    ```
 
 2. Check provider configuration in agent code

--- a/agent-evaluation/scripts/validate_auth.py
+++ b/agent-evaluation/scripts/validate_auth.py
@@ -171,6 +171,9 @@ def check_llm_provider():
     if os.getenv("ANTHROPIC_API_KEY"):
         providers_found.append("Anthropic")
 
+    if os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY"):
+        providers_found.append("Gemini")
+
     if os.getenv("DATABRICKS_TOKEN") or os.getenv("DATABRICKS_HOST"):
         providers_found.append("Databricks")
 

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: instrumenting-with-mlflow-tracing
-description: Instruments Python and TypeScript code with MLflow Tracing for observability. Must be loaded when setting up tracing as part of any workflow including agent evaluation. Triggers on adding tracing, instrumenting agents/LLM apps, getting started with MLflow tracing, tracing specific frameworks (LangGraph, LangChain, OpenAI, DSPy, CrewAI, AutoGen), or when another skill references tracing setup. Examples - "How do I add tracing?", "Instrument my agent", "Trace my LangChain app", "Set up tracing for evaluation"
+description: Instruments Python and TypeScript code with MLflow Tracing for observability. Must be loaded when setting up tracing as part of any workflow including agent evaluation. Triggers on adding tracing, instrumenting agents/LLM apps, getting started with MLflow tracing, tracing specific frameworks (LangGraph, LangChain, OpenAI, Gemini, DSPy, CrewAI, AutoGen), or when another skill references tracing setup. Examples - "How do I add tracing?", "Instrument my agent", "Trace my LangChain app", "Set up tracing for evaluation"
 ---
 
 # MLflow Tracing Instrumentation Guide

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -62,6 +62,7 @@ import mlflow
 mlflow.langchain.autolog()    # LangChain, LangGraph
 mlflow.openai.autolog()       # OpenAI SDK
 mlflow.anthropic.autolog()    # Anthropic SDK
+mlflow.gemini.autolog()       # Google Gemini (google-genai SDK)
 mlflow.litellm.autolog()      # LiteLLM
 mlflow.dspy.autolog()         # DSPy
 mlflow.autogen.autolog()      # AutoGen

--- a/mlflow-onboarding/SKILL.md
+++ b/mlflow-onboarding/SKILL.md
@@ -21,7 +21,7 @@ Before recommending tutorials or integration steps, determine which use case the
 Search the user's project for imports and usage patterns that indicate the use case:
 
 **GenAI indicators** (any of these suggest GenAI):
-- Imports from LLM client libraries: `openai`, `anthropic`, `google.generativeai`, `langchain`, `langchain_openai`, `langgraph`, `llamaindex`, `litellm`, `autogen`, `crewai`, `dspy`
+- Imports from LLM client libraries: `openai`, `anthropic`, `google.generativeai`, `google.genai`, `langchain`, `langchain_openai`, `langgraph`, `llamaindex`, `litellm`, `autogen`, `crewai`, `dspy`
 - Imports from MLflow GenAI modules: `mlflow.genai`, `mlflow.tracing`, `mlflow.openai`, `mlflow.langchain`
 - Usage of chat completions, embeddings, or agent frameworks
 - Prompt templates or prompt engineering code
@@ -136,6 +136,7 @@ mock_chat("What is MLflow?")
    # Pick the one that matches the user's LLM provider:
    mlflow.openai.autolog()       # OpenAI SDK
    mlflow.anthropic.autolog()    # Anthropic SDK
+   mlflow.gemini.autolog()       # Google Gemini (google-genai SDK)
    mlflow.langchain.autolog()    # LangChain / LangGraph
    mlflow.litellm.autolog()      # LiteLLM
    ```


### PR DESCRIPTION
## Summary 
The skills cover OpenAI, Anthropic, LangChain, and LiteLLM as tracing/eval providers, but none of them mention Google Gemini even though MLflow has first-class Gemini provider integration. 
While using the tracing and evaluation skills on a Gemini project, the agent had no Gemini path to follow. `mlflow-onboarding` actually detects a Gemini project (looks for the `google.generativeai` import) but then offers no Gemini setup line.
This PR adds Gemini/Google as a first-class provider everywhere the other providers are listed, after verifying it works end-to-end on MLflow 3.12.

## Changes
1. `instrumenting-with-mlflow-tracing`  - added `mlflow.gemini.autolog()` to the autolog list (`references/python.md`).
- added "Gemini" to the skill's trigger list so it loads for Gemini questions.
2. `mlflow-onboarding` - added the `mlflow.gemini.autolog()` line to the setup snippet. 
- added `google.genai` to the GenAI import detection.
3. `agent-evaluation` - added a `gemini:/<model>` row to the judge model-URI table (`references/scorers.md`). 
- added Gemini/Google detection to `scripts/validate_auth.py`.

## Note
The examples below use the current `google.genai` SDK, not the older `google.generativeai` (deprecated). I checked
that `mlflow.gemini.autolog()` traces `google.genai` calls with token usage on 3.12, so the downstream skills (metrics, trace analysis) get the data they expect.

## Verification 
Local MLflow server + AI Studio key for the Gemini calls. OpenAI only as the eval judge. 
I used a small two-step agent (a `@mlflow.trace` tool feeding a Gemini call) so the trace has a tree.

<img width="2550" height="627" alt="1" src="https://github.com/user-attachments/assets/1be352c3-e49e-4ba5-80b7-04dead1dda34" />

`mlflow.gemini.autolog()` traces the app end-to-end (AGENT → TOOL → LLM) with token usage, a `gemini:/<model>` judge URI resolves, and `querying-mlflow-metrics` aggregates the Gemini token usage:

<img width="1839" height="1027" alt="2" src="https://github.com/user-attachments/assets/cda70923-08cd-4e4f-93fe-6bbb2bee9a74" />

The updated `validate_auth.py` now reports Gemini too, it previously only knew OpenAI / Anthropic / Databricks:

<img width="1268" height="764" alt="3" src="https://github.com/user-attachments/assets/0da11f9d-0c43-4934-9b4b-5ee1ddd51725" />

## Test plan

- [x] `mlflow.gemini.autolog()` traces a `google.genai` app end-to-end; spans + token usage captured
- [x] `querying-mlflow-metrics/scripts/fetch_metrics.py` returns Gemini token totals
- [x] `gemini:/gemini-3.1-flash-lite` works as a `make_judge` model
- [x] `validate_auth.py` lists Gemini when `GEMINI_API_KEY` / `GOOGLE_API_KEY` is set
- [ ] `tests/configs/gemini_tracing_test.yaml` [happy to add a harness config if you'd like CI coverage]