### PR TITLE
fix(tracing): flush async trace queue before verifying traces

### DIFF
--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -49,11 +49,12 @@ After instrumenting the code, **always verify that tracing is working**.
 
 
 1. **Run the instrumented code** — execute the application or agent so that at least one traced operation fires
-2. **Confirm traces are logged** — use `mlflow.search_traces()` or `MlflowClient().search_traces()` to check that traces appear in the experiment:
+2. **Confirm traces are logged** — traces export on a background queue, so flush it first, then use `mlflow.search_traces()` or `MlflowClient().search_traces()` to check that traces appear in the experiment:
 
 ```python
 import mlflow
 
+mlflow.flush_trace_async_logging()
 traces = mlflow.search_traces(experiment_ids=["<experiment_id>"])
 print(f"Found {len(traces)} trace(s)")
 assert len(traces) > 0, "No traces were logged — check tracking URI and experiment settings"
@@ -75,6 +76,7 @@ for span in spans:
 
 Check these in order:
 
+- **Verification ran before traces were exported** — trace logging is asynchronous by default, so an in-process `search_traces()` right after the run can return zero before the background queue flushes (up to a few seconds later). Call `mlflow.flush_trace_async_logging()` before searching, as shown above.
 - **Tracking URI not set** — is `mlflow.set_tracking_uri(...)` called before the agent run? Without this, traces go to a local `./mlruns` directory instead of the configured server.
 - **Autolog warnings** — did `mlflow.autolog()` or framework-specific `mlflow.<framework>.autolog()` raise any warnings during setup? Check stderr for patching failures.
 - **Wrong experiment ID** — verify the experiment ID passed to `search_traces()` matches the experiment active when the code ran (`mlflow.get_experiment_by_name(...)` to confirm).

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -49,7 +49,7 @@ After instrumenting the code, **always verify that tracing is working**.
 
 
 1. **Run the instrumented code** — execute the application or agent so that at least one traced operation fires
-2. **Confirm traces are logged** — traces export on a background queue, so flush it first, then use `mlflow.search_traces()` or `MlflowClient().search_traces()` to check that traces appear in the experiment:
+2. **Confirm traces are logged** — use `mlflow.search_traces()` or `MlflowClient().search_traces()` to check that traces appear in the experiment. If the trace is not found, try `mlflow.flush_trace_async_logging()` to flush the background queue.
 
 ```python
 import mlflow


### PR DESCRIPTION
## Summary

The Verification step in `instrumenting-with-mlflow-tracing` searches for traces in-process right after the run and asserts at least one exists:

```python
traces = mlflow.search_traces(experiment_ids=["<experiment_id>"])
assert len(traces) > 0, "No traces were logged ..."
```

MLflow exports traces on a background queue. `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING` is `True` by default and the queue flushes at most every `MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS` (5000 ms), so a search immediately after the run can return zero before the trace is exported. A coding agent following this skill then reports that tracing failed when it actually worked. The "If no traces appear" list did not mention the export timing, so the agent works through the wrong checks before reaching `agent-evaluation`.

The fix is to drain that queue before searching, so verification runs against the exported trace instead of racing it.

## Changes

`instrumenting-with-mlflow-tracing/SKILL.md`, Verification step:
- Call `mlflow.flush_trace_async_logging()` before `search_traces()`. It flushes the queued traces to the backend before returning, so the just-finished trace is present when the assert runs.
- Add the async-export timing as the first item in the "If no traces appear" list.

`references/production.md:64` already registers `mlflow.flush_trace_async_logging` at exit. This applies the same call at the point the skill asserts on the result.

## Verification

Reproduced on MLflow 3.12 with a one-call Gemini app against a local sqlite store:

```
[bug]  no flush, search right after the call: 0 new trace(s)  <-- SKILL.md verify step
       trace became queryable 3.86s later -> the 0 above was a FALSE NEGATIVE
[fix]  flush_trace_async_logging() then search: 1 new trace(s)  <-- queryable immediately
2026/06/03 03:05:17 INFO mlflow.tracing.export.async_export_queue: Flushing the async trace logging queue before program exit. This may take a while...
```