### PR TITLE
Fix plugin.json so the plugin installs on current Claude Code

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,22 +3,22 @@
   "displayName": "MLflow Skills",
   "description": "Skills for tracing, evaluating, and improving AI agents with MLflow. Supports the full agent improvement loop: instrument → trace → evaluate → iterate → validate.",
   "version": "1.0.0",
-  "author": "MLflow Team",
+  "author": {
+    "name": "MLflow Team"
+  },
   "homepage": "https://github.com/mlflow/skills",
   "skills": [
-    "mlflow-agent",
-    "agent-evaluation",
-    "instrumenting-with-mlflow-tracing",
-    "analyze-mlflow-trace",
-    "analyze-mlflow-chat-session",
-    "retrieving-mlflow-traces",
-    "querying-mlflow-metrics",
-    "mlflow-onboarding",
-    "searching-mlflow-docs"
+    "./mlflow-agent",
+    "./agent-evaluation",
+    "./instrumenting-with-mlflow-tracing",
+    "./analyze-mlflow-trace",
+    "./analyze-mlflow-chat-session",
+    "./retrieving-mlflow-traces",
+    "./querying-mlflow-metrics",
+    "./mlflow-onboarding",
+    "./searching-mlflow-docs"
   ],
-  "hooks": [
-    "hooks/mlflow-suggest-hook.py"
-  ],
+  "hooks": "./hooks/hooks.json",
   "categories": ["observability", "evaluation", "ai-agents"],
   "minClaudeCodeVersion": "2.0.0"
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/mlflow-suggest-hook.py"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

The plugin currently fails to install via `claude plugin install` on recent Claude Code releases (verified on v2.1.170) because of three `plugin.json` schema issues. This PR fixes them so the plugin installs and all 9 skills + the hook register.

## Changes

1. **`author`** — changed from a string to an object (`{"name": "MLflow Team"}`). Recent CLI versions validate `author` as an object and reject the string form.
2. **`skills[]`** — added the `./` path prefix to each entry. Without it the loader rejects the entries at install time, so no skills register.
3. **`hooks`** — replaced the bare script-path array with a reference to a new `hooks/hooks.json` config (added) that wires the existing `mlflow-suggest-hook.py` to the `UserPromptSubmit` event. Plugin hooks are configured via a hooks JSON file rather than a list of script paths.

## Verification

Installed the patched plugin from a local marketplace on Claude Code v2.1.170:

- **Before:** `✘ Failed to install … Validation errors: author …, hooks …, skills …`
- **After:** `✔ Successfully installed` — `claude plugin details mlflow` reports **Skills (9)** and **Hooks (1, UserPromptSubmit)**.