### PR TITLE
support SageMaker Managed MLflow across skills

### DIFF
--- a/agent-evaluation/scripts/setup_mlflow.py
+++ b/agent-evaluation/scripts/setup_mlflow.py
@@ -48,6 +48,27 @@ def check_mlflow_installed() -> bool:
         return False
 
 
+def ensure_backend_plugin(tracking_uri: str) -> None:
+    """Ensure the backend plugin for the chosen tracking URI is installed.
+
+    SageMaker Managed MLflow uses an ARN tracking URI
+    (arn:aws:sagemaker:<region>:<acct>:mlflow-app/<id> or .../mlflow-tracking-server/<name>),
+    which only works when the `sagemaker-mlflow` plugin is installed (it registers the
+    `arn` tracking scheme). Without it, set_tracking_uri(<arn>) raises
+    UnsupportedModelRegistryStoreURIException. Like check_mlflow_installed(), this reports
+    the fix rather than installing the plugin.
+    """
+    if tracking_uri.startswith("arn:aws:sagemaker:"):
+        try:
+            import sagemaker_mlflow  # noqa: F401
+
+            print("✓ sagemaker-mlflow plugin installed (SageMaker Managed MLflow)")
+        except ImportError:
+            print("✗ SageMaker Managed MLflow detected but sagemaker-mlflow is not installed")
+            print("  Install with: pip install sagemaker-mlflow")
+            sys.exit(1)
+
+
 def detect_databricks_profiles() -> list[str]:
     """Detect available and valid Databricks profiles.
 
@@ -279,6 +300,9 @@ def main():
 
     # Configure tracking URI (auto-detects if not provided)
     tracking_uri = configure_tracking_uri(args.tracking_uri)
+
+    # Ensure the backend plugin (e.g. sagemaker-mlflow for SageMaker ARN URIs) is installed
+    ensure_backend_plugin(tracking_uri)
 
     # Configure experiment ID (auto-detects if not provided)
     experiment_id = configure_experiment_id(

--- a/agent-evaluation/scripts/validate_auth.py
+++ b/agent-evaluation/scripts/validate_auth.py
@@ -116,6 +116,70 @@ def check_databricks_auth():
         ]
 
 
+def check_sagemaker_auth():
+    """Test SageMaker Managed MLflow authentication.
+
+    Validates the three prerequisites for the SageMaker backend:
+      1. the sagemaker-mlflow plugin is installed (registers the `arn` tracking scheme),
+      2. AWS credentials are present in the environment,
+      3. the resource ARN tracking URI actually connects.
+
+    Mirrors check_databricks_auth(): this NEVER installs the plugin and NEVER acquires
+    credentials -- it validates and returns remediation messages for main() to report.
+    """
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI", "")
+
+    if not tracking_uri.startswith("arn:aws:sagemaker:"):
+        print("  ⊘ Not using SageMaker Managed MLflow (skipped)")
+        print()
+        return []
+
+    print("Testing SageMaker Managed MLflow authentication...")
+
+    # Requirement 2: sagemaker-mlflow plugin must be installed (it brings boto3 with it).
+    # Like the Databricks SDK check, we report the fix instead of installing it.
+    try:
+        import sagemaker_mlflow  # noqa: F401
+        import boto3
+
+        print("  ✓ sagemaker-mlflow plugin installed")
+    except ImportError:
+        print("  ✗ sagemaker-mlflow plugin (or its boto3 dependency) not installed")
+        print()
+        return ["Install SageMaker MLflow plugin: pip install sagemaker-mlflow"]
+
+    # Requirement 1: AWS credentials must be present (validate only, never acquire).
+    try:
+        identity = boto3.client("sts").get_caller_identity()
+        print(f"  ✓ AWS credentials present ({identity['Arn']})")
+    except Exception as e:
+        print(f"  ✗ AWS credentials missing or expired: {str(e)[:80]}")
+        print()
+        return [
+            "Configure AWS credentials (aws configure, SSO, or an IAM role), "
+            "then verify with: aws sts get-caller-identity"
+        ]
+
+    # Requirement 3: the ARN tracking URI must connect (lightweight API call).
+    try:
+        from mlflow import MlflowClient
+
+        MlflowClient().search_experiments(max_results=1)
+        print(f"  ✓ Connected to SageMaker Managed MLflow: {tracking_uri}")
+        print()
+        return []
+    except Exception as e:
+        error_msg = str(e)
+        print(f"  ✗ Connection failed: {error_msg[:100]}")
+        print()
+        if "403" in error_msg or "AccessDenied" in error_msg:
+            return [
+                "AWS principal lacks MLflow permissions on the resource "
+                "(needs sagemaker-mlflow / sagemaker actions on the ARN)"
+            ]
+        return [f"Cannot connect to {tracking_uri} - check the ARN, region, and network"]
+
+
 def check_mlflow_tracking():
     """Test MLflow tracking server connectivity."""
     print("Testing MLflow tracking server...")
@@ -205,7 +269,11 @@ def main():
     databricks_issues = check_databricks_auth()
     all_issues.extend(databricks_issues)
 
-    # Check 3: LLM provider (optional check)
+    # Check 3: SageMaker Managed MLflow auth (if using a SageMaker ARN)
+    sagemaker_issues = check_sagemaker_auth()
+    all_issues.extend(sagemaker_issues)
+
+    # Check 4: LLM provider (optional check)
     llm_issues = check_llm_provider()
     all_issues.extend(llm_issues)
 

--- a/sagemaker-mlflow/SKILL.md
+++ b/sagemaker-mlflow/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: sagemaker-mlflow
+description: >
+  Connect to SageMaker Managed MLflow (mlflow-app or mlflow-tracking-server ARN) as an
+  MLflow backend, then hand off to the other MLflow skills. Triggers on a SageMaker MLflow
+  ARN (arn:aws:sagemaker:...:mlflow-app/... or arn:aws:sagemaker:...:mlflow-tracking-server/...)
+  or "SageMaker Managed MLflow".
+---
+
+# Connect to SageMaker MLflow
+
+Establishes the connection to SageMaker Managed MLflow (the `sagemaker-mlflow` plugin + an
+ARN tracking URI + AWS credentials), then hands off to the requested MLflow skill
+(instrumenting-with-mlflow-tracing, agent-evaluation, retrieving-mlflow-traces,
+querying-mlflow-metrics, etc.), which inherit the connection via `MLFLOW_TRACKING_URI`.
+
+Requires **Python >= 3.10** (mlflow >= 3.8). Validate and report the fix — never
+auto-install the plugin or acquire credentials (mirrors the repo's Databricks pattern).
+
+## Step 1: Preconditions
+- `python --version` -> must be 3.10+. If older, STOP and tell the user.
+- Confirm AWS credentials resolve (env vars, `aws configure` / SSO, or an IAM role). If
+  they error (ExpiredToken / no creds), STOP and ask the user to configure them.
+  (`scripts/verify_connection.py` also checks this, via boto3.)
+
+## Step 2: Install the plugin
+```bash
+pip install sagemaker-mlflow
+```
+Required even if `MLFLOW_TRACKING_URI` is already an ARN — without it,
+`mlflow.set_tracking_uri()` fails with `UnsupportedModelRegistryStoreURIException`.
+
+## Step 3: Select the resource ARN
+- **If the user already provided an ARN** (or `MLFLOW_TRACKING_URI` is set to
+  `arn:aws:sagemaker:...`), use it as-is.
+- **Otherwise, discover it** in the user's region:
+  ```bash
+  python scripts/discover_arns.py
+  ```
+  If exactly one is returned, use it; if several, list name/status/ARN and ask the user
+  which to use. Both `mlflow-app` and `mlflow-tracking-server` ARNs work; the ARN is also
+  shown on the resource's detail page in the SageMaker Studio console.
+
+Then export it (the ARN is region-bound — a cross-region ARN will not authenticate):
+```bash
+export MLFLOW_TRACKING_URI="<arn>"    # mlflow-app/<id> or mlflow-tracking-server/<name>
+export AWS_DEFAULT_REGION="<region>"  # AWS credentials resolved via the default chain (SigV4)
+```
+
+## Step 4: Verify
+```bash
+python scripts/verify_connection.py "$MLFLOW_TRACKING_URI"
+```
+Checks all three prerequisites (plugin / credentials / ARN connectivity) and exits
+non-zero with a remediation hint on the first failure. Do not proceed until it passes.
+
+After the connection verifies, hand off to the requested MLflow skill — it inherits the
+connected environment via `MLFLOW_TRACKING_URI`.
+
+## Troubleshooting
+- `UnsupportedModelRegistryStoreURIException` — the `sagemaker-mlflow` plugin is not
+  installed; `pip install sagemaker-mlflow`, then re-run `scripts/verify_connection.py`.
+- `AccessDenied` / `403` — credentials are missing/expired, or the principal lacks MLflow
+  permissions on the ARN. Check that credentials resolve, grant `sagemaker-mlflow` /
+  `sagemaker` permissions, and confirm the ARN region matches `AWS_DEFAULT_REGION`.

--- a/sagemaker-mlflow/scripts/discover_arns.py
+++ b/sagemaker-mlflow/scripts/discover_arns.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""List SageMaker Managed MLflow resources (ARNs) in a region.
+
+Usage:
+    python discover_arns.py [<region>]
+
+Region defaults to $AWS_DEFAULT_REGION. Prints the ARN, name, and status for both serverless
+mlflow-apps and managed mlflow-tracking-servers so you can pick the tracking URI.
+"""
+import os
+import sys
+
+
+def main() -> None:
+    region = sys.argv[1] if len(sys.argv) > 1 else os.getenv("AWS_DEFAULT_REGION")
+    if not region:
+        print("Provide a region (argument or AWS_DEFAULT_REGION).")
+        sys.exit(2)
+
+    try:
+        import boto3
+    except ImportError:
+        print("boto3 not installed  ->  pip install sagemaker-mlflow")
+        sys.exit(1)
+
+    sm = boto3.client("sagemaker", region_name=region)
+    found = 0
+
+    try:
+        for a in sm.list_mlflow_apps().get("Summaries", []):
+            print(f"app              {a['Arn']}  ({a.get('Name')}, {a.get('Status')})")
+            found += 1
+    except Exception as e:  # noqa: BLE001
+        print(f"(list_mlflow_apps unavailable: {str(e)[:80]})")
+
+    try:
+        for t in sm.list_mlflow_tracking_servers().get("TrackingServerSummaries", []):
+            print(
+                f"tracking-server  {t['TrackingServerArn']}  "
+                f"({t.get('TrackingServerName')}, {t.get('TrackingServerStatus')})"
+            )
+            found += 1
+    except Exception as e:  # noqa: BLE001
+        print(f"(list_mlflow_tracking_servers unavailable: {str(e)[:80]})")
+
+    if not found:
+        print(f"No SageMaker MLflow resources found in {region}. Create one, or check the region.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sagemaker-mlflow/scripts/verify_connection.py
+++ b/sagemaker-mlflow/scripts/verify_connection.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Verify SageMaker Managed MLflow prerequisites: plugin, AWS credentials, ARN connectivity.
+
+Usage:
+    python verify_connection.py [<arn>]
+
+The ARN defaults to $MLFLOW_TRACKING_URI. This script validates only -- it never installs the
+plugin and never acquires credentials. It exits non-zero with a remediation hint on the first
+failing prerequisite.
+"""
+import os
+import sys
+
+
+def main() -> None:
+    arn = sys.argv[1] if len(sys.argv) > 1 else os.getenv("MLFLOW_TRACKING_URI", "")
+    if not arn.startswith("arn:aws:sagemaker:"):
+        print(
+            "Provide a SageMaker MLflow ARN (argument or MLFLOW_TRACKING_URI):\n"
+            "  arn:aws:sagemaker:<region>:<account>:mlflow-app/<id>  or\n"
+            "  arn:aws:sagemaker:<region>:<account>:mlflow-tracking-server/<name>"
+        )
+        sys.exit(2)
+
+    # 1. Plugin installed (registers the `arn` tracking scheme; it brings boto3 with it).
+    try:
+        import sagemaker_mlflow  # noqa: F401
+        import boto3
+
+        print("[ok] sagemaker-mlflow plugin installed")
+    except ImportError:
+        print("[x] sagemaker-mlflow plugin (or its boto3 dependency) not installed  ->  pip install sagemaker-mlflow")
+        sys.exit(1)
+
+    # 2. AWS credentials present (validate only, never acquire).
+    try:
+        identity = boto3.client("sts").get_caller_identity()
+        print(f"[ok] AWS credentials present ({identity['Arn']})")
+    except Exception as e:  # noqa: BLE001
+        print(f"[x] AWS credentials missing or expired: {str(e)[:100]}")
+        print("    Configure via env vars, `aws configure`/SSO, or an IAM role, then retry.")
+        sys.exit(1)
+
+    # 3. ARN tracking URI connects.
+    try:
+        import mlflow
+
+        mlflow.set_tracking_uri(arn)
+        mlflow.search_experiments(max_results=1)
+        print(f"[ok] Connected to {arn}")
+    except Exception as e:  # noqa: BLE001
+        msg = str(e)
+        if "403" in msg or "AccessDenied" in msg:
+            print(
+                "[x] AccessDenied/403  ->  the AWS principal needs sagemaker-mlflow / sagemaker "
+                "permissions on the resource ARN"
+            )
+        else:
+            print(f"[x] Cannot connect to {arn}: {msg[:120]}")
+        sys.exit(1)
+
+    print("All SageMaker Managed MLflow prerequisites satisfied.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# Support SageMaker Managed MLflow as a tracking backend

Fixes #23

## Summary

Adds **SageMaker Managed MLflow** as a first-class tracking backend for the MLflow skills,
alongside the existing Databricks and local backends. SageMaker exposes MLflow via a resource
**ARN tracking URI** (`arn:aws:sagemaker:<region>:<account>:mlflow-tracking-server/<name>` or
`.../mlflow-app/<id>`), which requires the [`sagemaker-mlflow`](https://github.com/aws/sagemaker-mlflow)
plugin to register the `arn` tracking scheme.

The change is **documentation + validation only** — it does not modify any skill's runtime logic,
and it is fully backwards compatible (all new behavior is gated on `arn:aws:sagemaker:` URIs).

## Motivation

Per #23, AWS SageMaker AI hosted MLflow needs the `sagemaker-mlflow` auth plugin and an ARN
tracking URI. Without the plugin, `mlflow.set_tracking_uri(<arn>)` fails with
`UnsupportedModelRegistryStoreURIException`. Today the skills have no guidance for this path, so a
user on SageMaker Managed MLflow cannot self-serve. This PR documents the three prerequisites,
helps users discover their ARN, and validates the setup — following the same "validate and report
the fix, never auto-install" pattern the repo already uses for Databricks.

## The three prerequisites (and how they are handled)

1. **AWS credentials present** in the environment.
2. **`sagemaker-mlflow` installed** (registers the `arn` tracking scheme).
3. **The resource ARN used as `MLFLOW_TRACKING_URI`**.

`validate_auth.py` now validates all three and **returns remediation messages** (it never installs
the plugin and never acquires credentials) — mirroring the existing `check_databricks_auth()` which
reports `pip install databricks-sdk` rather than installing it.

## Changes

New top-level skill `sagemaker-mlflow/`:
- `SKILL.md` — thin entry point ("Connect to SageMaker MLflow"); triggers on a
  SageMaker MLflow ARN / "managed MLflow" / "SageMaker MLflow", then points to the
  reference and hands off to the other MLflow skills.
- `references/connect-sagemaker-managed-mlflow.md` — single source of the connection
  steps: 3 preconditions → `pip install sagemaker-mlflow` → ARN selection
  (provided → use as-is; else discover) → verify → guardrails + troubleshooting.
- `scripts/verify_connection.py` — validates 3 prerequisites (plugin installed /
  AWS creds present / ARN URI connects). Verify-only: never installs or acquires
  credentials; exits non-zero with a hint on failure.
- `scripts/discover_arns.py` — lists `mlflow-app` + `mlflow-tracking-server` ARNs
  (name / status / ARN) in a region for the resolve-or-ask flow.

Preserved helper changes in `agent-evaluation/scripts/` (used by the evaluation flow):
- `validate_auth.py` — adds `check_sagemaker_auth()` (same 3-prereq check, mirrors
  the existing Databricks pattern; validate-only).
- `setup_mlflow.py` — `ensure_backend_plugin` guard: fast-fail with an install hint
  when an ARN URI is used without the plugin.

Net: +336 / −1 across 6 files. All other (vendor-neutral) skills are unchanged.

## Testing

Validated against a real SageMaker Managed MLflow app (`mlflow-app`, us-west-2), Python 3.11, `mlflow 3.14.0`.

### Prerequisite validation (validate_auth.py / setup_mlflow.py)

| # | Scenario | Result |
|---|---|---|
| T1 | Plugin missing | Returns `Install SageMaker MLflow plugin: pip install sagemaker-mlflow` (never installs) |
| T2 | Plugin present, creds missing/expired | Returns AWS-credentials remediation (never acquires creds) |
| T3 | Plugin + creds + ARN (happy path) | All three checks pass, connected, no issues |
| T4 | `setup_mlflow.py` guard, ARN without plugin | Fails fast with `Install with: pip install sagemaker-mlflow` |
| T5 | ARN discovery | `aws sagemaker list-mlflow-apps` / `list-mlflow-tracking-servers` return ARN + name + status |
| T6 | End-to-end | 3-span trace (`run_agent`/`retrieve`/`generate`) lands on managed |

### Regression (non-SageMaker backends unaffected)

- `check_sagemaker_auth()` skips and returns `[]` for `local` / `databricks` URIs.
- `ensure_backend_plugin()` is a no-op for non-ARN URIs.
- `setup_mlflow.py` still configures local sqlite end-to-end.

### Skills validated against managed (real `npx skills add` + kiro-cli)

All operational skills were installed via the real installer and driven end-to-end against managed:

| Skill | Result |
|---|---|
| instrumenting-with-mlflow-tracing | trace landed (3 spans) |
| retrieving-mlflow-traces | listed trace + span tree |
| querying-mlflow-metrics | count + mean/p50/p95 |
| analyzing-mlflow-trace | walked spans + timing |
| mlflow-onboarding | run logged (param + metric) |
| agent-evaluation | code-based scorer ran (LLM judges are not available on managed; code-based scorers are the supported path) |
| analyzing-mlflow-chat-session | reconstructed a multi-turn session |
| searching-mlflow-docs | fetched + cited docs |

## Notes

- **Vendor-neutral:** SageMaker is added as a peer backend (like Databricks/local); the ARN
  discovery + plugin guidance live in the existing backend sections.
- **Optional dependency:** `sagemaker-mlflow` is only needed for ARN tracking URIs; nothing changes
  for existing users.
- **Credentials/permissions:** credentials come from the standard AWS chain (env vars, profile/SSO,
  or an IAM role inside SageMaker/EC2); the principal needs `sagemaker-mlflow` / `sagemaker`
  permissions on the resource ARN. The ARN is region-bound (a cross-region ARN will not authenticate).

## Acknowledgment

By submitting this pull request, I confirm that the contribution is made under the terms of the
project's license.
