### PR TITLE
Register fix-agent-issue and sagemaker-mlflow skills in plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,7 +16,9 @@
     "./retrieving-mlflow-traces",
     "./querying-mlflow-metrics",
     "./mlflow-onboarding",
-    "./searching-mlflow-docs"
+    "./searching-mlflow-docs",
+    "./fix-agent-issue",
+    "./sagemaker-mlflow"
   ],
   "hooks": "./hooks/hooks.json",
   "categories": ["observability", "evaluation", "ai-agents"],


### PR DESCRIPTION
## Problem

Two skill directories were added to the repo after `plugin.json` was last updated but were never listed in its `skills` array:

- `fix-agent-issue` (added in #22)
- `sagemaker-mlflow` (added in #25, after `plugin.json` was rewritten in #21)

Because the plugin only exposes skills enumerated in `plugin.json`, these two skills aren't available to users who install the plugin — even though the directories are present in the repo.

## Change

Add `./fix-agent-issue` and `./sagemaker-mlflow` to the `skills` list in `.claude-plugin/plugin.json`.

## Verification

- `plugin.json` remains valid JSON (11 skills now listed).
- Every listed skill entry resolves to a real directory containing a `SKILL.md`.
- The set of on-disk skill directories now matches the `skills` list exactly — no skill directory is left unregistered.

This pull request and its description were written by Isaac.