### PR TITLE
Add docs for storing traces in Unity Catalog on Databricks

### DIFF
--- a/analyze-mlflow-trace/references/trace-structure.md
+++ b/analyze-mlflow-trace/references/trace-structure.md
@@ -90,7 +90,7 @@ An optional identifier provided by the calling system (e.g., a web server reques
 
 Where this trace is stored. Can be:
 - **MlflowExperimentLocation**: Stored in an MLflow experiment, identified by `experiment_id`. This is the most common case for development and OSS deployments.
-- **UCSchemaLocation**: Stored in a Databricks Unity Catalog schema, identified by `catalog_name` and `schema_name`. Used in production Databricks deployments for governed trace storage.
+- **UnityCatalog**: Stored in Databricks Unity Catalog Delta tables, identified by `catalog_name`, `schema_name`, and `table_prefix` (the prefix on the `<table_prefix>_otel_*` tables holding the trace data). A single schema can hold multiple trace locations, one per `table_prefix`. Used in production Databricks deployments for governed trace storage.
 
 The location determines which tracking server or catalog to query when fetching the trace's full data.
 

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -118,3 +118,7 @@ See `references/advanced-patterns.md` for:
 See `references/distributed-tracing.md` for:
 - Propagating trace context across services
 - Client/server header APIs
+
+### Databricks (Unity Catalog storage)
+
+See `references/databricks.md` for storing traces in Unity Catalog Delta tables by binding an experiment to a `UnityCatalog` trace location (catalog, schema, table prefix).

--- a/instrumenting-with-mlflow-tracing/references/databricks.md
+++ b/instrumenting-with-mlflow-tracing/references/databricks.md
@@ -1,0 +1,30 @@
+# Tracing on Databricks (Unity Catalog storage)
+
+On Databricks, traces can be stored in **Unity Catalog Delta tables** for governed, production-grade storage. Bind an MLflow experiment to a UC trace location, then instrument code as usual — all traces logged to that experiment land in those tables.
+
+```python
+import os
+import mlflow
+from mlflow.entities.trace_location import UnityCatalog
+
+mlflow.set_tracking_uri("databricks")
+os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = "<SQL_WAREHOUSE_ID>"
+
+mlflow.set_experiment(
+    experiment_name="<MLFLOW_EXPERIMENT_NAME>",
+    trace_location=UnityCatalog(
+        catalog_name="<UC_CATALOG_NAME>",
+        schema_name="<UC_SCHEMA_NAME>",
+        table_prefix="<UC_TABLE_PREFIX>",
+    ),
+)
+```
+
+**`table_prefix`** is the prefix applied to every table storing trace data. MLflow creates four Delta tables from it: `<table_prefix>_otel_spans`, `<table_prefix>_otel_logs`, `<table_prefix>_otel_metrics`, and `<table_prefix>_otel_annotations`.
+
+**Notes**:
+- Requires a SQL warehouse (`MLFLOW_TRACING_SQL_WAREHOUSE_ID`) to provision and query the tables.
+- A UC trace location is permanent — once bound, an experiment cannot be reassigned to a different UC location.
+- To create the experiment explicitly, use `mlflow.create_experiment(name=..., trace_location=UnityCatalog(...))`, then `mlflow.set_experiment(experiment_id=...)`.
+
+Docs: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog


### PR DESCRIPTION
Adds guidance for storing MLflow traces in Unity Catalog Delta tables on Databricks.

- The tracing instrumentation skill now explains how to send traces to a Unity Catalog location (catalog, schema, table prefix) so users on Databricks can keep traces in governed tables.
- The trace analysis reference now describes the Unity Catalog trace location, so users understand where a trace is stored and how to read it.

Docs: https://docs.databricks.com/aws/en/mlflow3/genai/tracing/trace-unity-catalog