### PR TITLE
Set a readable root-span request and response

### DIFF
--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -87,53 +87,9 @@ def search_database(sql: str) -> dict:
 
 **Span types**: `LLM`, `CHAIN`, `TOOL`, `AGENT`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `PARSER`, `UNKNOWN`
 
-**Caution: the decorator auto-captures raw function arguments AND return value.** `span.set_inputs()` inside the body correctly overrides the auto-captured inputs. `span.set_outputs()` inside the body does not: the decorator calls `span.set_outputs(return_value)` after the function exits, so the return value always wins.
+**Caution: the decorator auto-captures raw function arguments AND return value.** `span.set_inputs()` inside the body correctly overrides the auto-captured inputs. The decorator sets outputs from the function's return value after the function exits, so an in-body `span.set_outputs()` does not override them.
 
-**First check whether you need to do anything.** MLflow already derives readable trace-list previews for OpenAI chat-shaped payloads: a top-level `messages` list, `choices[0].message`, or a Responses-API `input` list. When the root span's input or output matches one of those, the preview shows the last user or assistant message text and needs no help. Do not set previews manually in that case.
-
-The patterns below are for a root span whose input or output is **not** chat-shaped, such as an agent state dict (`{"customer": ..., "note_text": ..., "output_path": ...}`). There are no messages to extract, so the preview falls back to the serialized object truncated to the max length, which cuts mid-JSON.
-
-**Option 1: Set compact trace-list previews with `update_current_trace`.** The `request_preview` and `response_preview` fields control what the Trace list UI shows. The root span still stores the full return value, but the list view shows your compact strings.
-
-```python
-from mlflow.entities import SpanType
-
-@mlflow.trace(span_type=SpanType.AGENT)
-def run_agent(graph, customer: str, date: str) -> dict:
-    span = mlflow.get_current_active_span()
-    span.set_inputs({"customer": customer, "date": date})  # overrides inputs correctly
-
-    state = graph.invoke({"customer": customer, "date": date})
-
-    output_path = state.get("output_path", "")
-    preview = (state.get("note_text") or "")[:200]
-    mlflow.update_current_trace(
-        request_preview=f"customer={customer}, date={date}",
-        response_preview=f"output_path={output_path}, preview={preview}",
-    )
-
-    return state
-```
-
-**Option 2: Use a manual span (Method 3) as the entry point.** This gives full control over both the stored inputs and outputs on the root span.
-
-```python
-from mlflow.entities import SpanType
-
-def run_agent(graph, customer: str, date: str) -> dict:
-    with mlflow.start_span(name="run_agent", span_type=SpanType.AGENT) as span:
-        span.set_inputs({"customer": customer, "date": date})
-
-        state = graph.invoke({"customer": customer, "date": date})
-
-        output_path = state.get("output_path", "")
-        preview = (state.get("note_text") or "")[:200]
-        span.set_outputs({"output_path": output_path, "preview": preview})
-
-        return state
-```
-
-Use Option 1 when you want to keep the decorator and only need the list view to be readable. Use Option 2 when you need the root span itself to store compact values.
+For non-chat-shaped root inputs or outputs that need a custom trace-list preview or compact stored values, see [Root span previews and compact values](root-span-previews.md).
 
 ### Method 3: Manual Spans (When Decorator Not Possible)
 

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -89,7 +89,9 @@ def search_database(sql: str) -> dict:
 
 **Caution: the decorator auto-captures raw function arguments AND return value.** `span.set_inputs()` inside the body correctly overrides the auto-captured inputs. `span.set_outputs()` inside the body does not: the decorator calls `span.set_outputs(return_value)` after the function exits, so the return value always wins.
 
-Two patterns work correctly when both the input and output are large objects.
+**First check whether you need to do anything.** MLflow already derives readable trace-list previews for OpenAI chat-shaped payloads: a top-level `messages` list, `choices[0].message`, or a Responses-API `input` list. When the root span's input or output matches one of those, the preview shows the last user or assistant message text and needs no help. Do not set previews manually in that case.
+
+The patterns below are for a root span whose input or output is **not** chat-shaped, such as an agent state dict (`{"customer": ..., "note_text": ..., "output_path": ...}`). There are no messages to extract, so the preview falls back to the serialized object truncated to the max length, which cuts mid-JSON.
 
 **Option 1: Set compact trace-list previews with `update_current_trace`.** The `request_preview` and `response_preview` fields control what the Trace list UI shows. The root span still stores the full return value, but the list view shows your compact strings.
 

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -87,6 +87,27 @@ def search_database(sql: str) -> dict:
 
 **Span types**: `LLM`, `CHAIN`, `TOOL`, `AGENT`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `PARSER`, `UNKNOWN`
 
+**Caution: the decorator auto-captures raw function arguments.** If the input is a compiled LangGraph graph or the output is a full state dict, the root span shows an unreadable blob. Override with compact values inside the function body:
+
+```python
+from mlflow.entities import SpanType
+
+@mlflow.trace(span_type=SpanType.AGENT)
+def run_agent(graph, customer: str, date: str) -> dict:
+    span = mlflow.get_current_active_span()
+    span.set_inputs({"customer": customer, "date": date})
+
+    state = graph.invoke({"customer": customer, "date": date})
+
+    output_path = state.get("output_path", "")
+    preview = state.get("note_text", "")[:200]
+    span.set_outputs({"output_path": output_path, "preview": preview})
+
+    return state
+```
+
+Use this pattern whenever the raw arguments or return value do not show what went in and what came out. Call `mlflow.get_current_active_span()` inside the decorated function to get the root span. Then call `span.set_inputs()` and `span.set_outputs()` to replace the auto-captured values.
+
 ### Method 3: Manual Spans (When Decorator Not Possible)
 
 Use only when you can't use a decorator:

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -87,7 +87,7 @@ def search_database(sql: str) -> dict:
 
 **Span types**: `LLM`, `CHAIN`, `TOOL`, `AGENT`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `PARSER`, `UNKNOWN`
 
-**Caution: the decorator auto-captures raw function arguments AND return value.** `span.set_inputs()` inside the body correctly overrides the auto-captured inputs. The decorator sets outputs from the function's return value after the function exits, so an in-body `span.set_outputs()` does not override them.
+**Caution: the decorator auto-captures raw function arguments and return value.** Set `span.set_inputs()` or `span.set_outputs()` inside the body when the span should store a more useful, compact value; explicit values take precedence over the decorator's automatic capture.
 
 For non-chat-shaped root inputs or outputs that need a custom trace-list preview or compact stored values, see [Root span previews and compact values](root-span-previews.md).
 

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -87,7 +87,11 @@ def search_database(sql: str) -> dict:
 
 **Span types**: `LLM`, `CHAIN`, `TOOL`, `AGENT`, `RETRIEVER`, `EMBEDDING`, `RERANKER`, `PARSER`, `UNKNOWN`
 
-**Caution: the decorator auto-captures raw function arguments.** If the input is a compiled LangGraph graph or the output is a full state dict, the root span shows an unreadable blob. Override with compact values inside the function body:
+**Caution: the decorator auto-captures raw function arguments AND return value.** `span.set_inputs()` inside the body correctly overrides the auto-captured inputs. `span.set_outputs()` inside the body does not: the decorator calls `span.set_outputs(return_value)` after the function exits, so the return value always wins.
+
+Two patterns work correctly when both the input and output are large objects.
+
+**Option 1: Set compact trace-list previews with `update_current_trace`.** The `request_preview` and `response_preview` fields control what the Trace list UI shows. The root span still stores the full return value, but the list view shows your compact strings.
 
 ```python
 from mlflow.entities import SpanType
@@ -95,18 +99,39 @@ from mlflow.entities import SpanType
 @mlflow.trace(span_type=SpanType.AGENT)
 def run_agent(graph, customer: str, date: str) -> dict:
     span = mlflow.get_current_active_span()
-    span.set_inputs({"customer": customer, "date": date})
+    span.set_inputs({"customer": customer, "date": date})  # overrides inputs correctly
 
     state = graph.invoke({"customer": customer, "date": date})
 
     output_path = state.get("output_path", "")
-    preview = state.get("note_text", "")[:200]
-    span.set_outputs({"output_path": output_path, "preview": preview})
+    preview = (state.get("note_text") or "")[:200]
+    mlflow.update_current_trace(
+        request_preview=f"customer={customer}, date={date}",
+        response_preview=f"output_path={output_path}, preview={preview}",
+    )
 
     return state
 ```
 
-Use this pattern whenever the raw arguments or return value do not show what went in and what came out. Call `mlflow.get_current_active_span()` inside the decorated function to get the root span. Then call `span.set_inputs()` and `span.set_outputs()` to replace the auto-captured values.
+**Option 2: Use a manual span (Method 3) as the entry point.** This gives full control over both the stored inputs and outputs on the root span.
+
+```python
+from mlflow.entities import SpanType
+
+def run_agent(graph, customer: str, date: str) -> dict:
+    with mlflow.start_span(name="run_agent", span_type=SpanType.AGENT) as span:
+        span.set_inputs({"customer": customer, "date": date})
+
+        state = graph.invoke({"customer": customer, "date": date})
+
+        output_path = state.get("output_path", "")
+        preview = (state.get("note_text") or "")[:200]
+        span.set_outputs({"output_path": output_path, "preview": preview})
+
+        return state
+```
+
+Use Option 1 when you want to keep the decorator and only need the list view to be readable. Use Option 2 when you need the root span itself to store compact values.
 
 ### Method 3: Manual Spans (When Decorator Not Possible)
 

--- a/instrumenting-with-mlflow-tracing/references/root-span-previews.md
+++ b/instrumenting-with-mlflow-tracing/references/root-span-previews.md
@@ -9,6 +9,7 @@ For other shapes, such as an agent state dict, the default preview is a serializ
 Use `span.set_inputs()` when you want compact stored inputs. Use `update_current_trace()` when only the trace list needs a readable request or response preview; the decorated function can still return the full state.
 
 ```python
+import mlflow
 from mlflow.entities import SpanType
 
 @mlflow.trace(span_type=SpanType.AGENT)
@@ -28,20 +29,21 @@ def run_agent(graph, customer: str, date: str) -> dict:
 
 ## Store compact inputs and outputs on the root span
 
-Use a manual root span only when the function must return the full state but the root span itself should store a compact output. A decorated function can set compact inputs, but its return value becomes the span output after the function exits.
+Keep the decorator when the function must return full state but the root span should store compact inputs or outputs. Explicit `span.set_inputs()` and `span.set_outputs()` values take precedence over the decorator's automatic capture.
 
 ```python
 from mlflow.entities import SpanType
 
+@mlflow.trace(span_type=SpanType.AGENT)
 def run_agent(graph, customer: str, date: str) -> dict:
-    with mlflow.start_span(name="run_agent", span_type=SpanType.AGENT) as span:
-        span.set_inputs({"customer": customer, "date": date})
-        state = graph.invoke({"customer": customer, "date": date})
-        span.set_outputs(
-            {
-                "output_path": state.get("output_path", ""),
-                "preview": state.get("note_text") or "",
-            }
-        )
-        return state
+    span = mlflow.get_current_active_span()
+    span.set_inputs({"customer": customer, "date": date})
+    state = graph.invoke({"customer": customer, "date": date})
+    span.set_outputs(
+        {
+            "output_path": state.get("output_path", ""),
+            "preview": state.get("note_text") or "",
+        }
+    )
+    return state
 ```

--- a/instrumenting-with-mlflow-tracing/references/root-span-previews.md
+++ b/instrumenting-with-mlflow-tracing/references/root-span-previews.md
@@ -1,0 +1,47 @@
+# Root span previews and compact values
+
+Use this pattern only when the root span's input or output is not already readable in the trace list. MLflow derives a readable preview automatically for OpenAI chat-shaped payloads: a top-level `messages` list, `choices[0].message`, or a Responses-API `input` list. Do not override those previews.
+
+For other shapes, such as an agent state dict, the default preview is a serialized object that can be hard to scan. The UI truncates long strings itself, so keep the useful value intact rather than adding an arbitrary slice in application code.
+
+## Keep the decorator and set a trace-list preview
+
+Use `span.set_inputs()` when you want compact stored inputs. Use `update_current_trace()` when only the trace list needs a readable request or response preview; the decorated function can still return the full state.
+
+```python
+from mlflow.entities import SpanType
+
+@mlflow.trace(span_type=SpanType.AGENT)
+def run_agent(graph, customer: str, date: str) -> dict:
+    span = mlflow.get_current_active_span()
+    span.set_inputs({"customer": customer, "date": date})
+
+    state = graph.invoke({"customer": customer, "date": date})
+    output_path = state.get("output_path", "")
+    preview = state.get("note_text") or ""
+    mlflow.update_current_trace(
+        request_preview=f"customer={customer}, date={date}",
+        response_preview=f"output_path={output_path}, preview={preview}",
+    )
+    return state
+```
+
+## Store compact inputs and outputs on the root span
+
+Use a manual root span only when the function must return the full state but the root span itself should store a compact output. A decorated function can set compact inputs, but its return value becomes the span output after the function exits.
+
+```python
+from mlflow.entities import SpanType
+
+def run_agent(graph, customer: str, date: str) -> dict:
+    with mlflow.start_span(name="run_agent", span_type=SpanType.AGENT) as span:
+        span.set_inputs({"customer": customer, "date": date})
+        state = graph.invoke({"customer": customer, "date": date})
+        span.set_outputs(
+            {
+                "output_path": state.get("output_path", ""),
+                "preview": state.get("note_text") or "",
+            }
+        )
+        return state
+```

--- a/instrumenting-with-mlflow-tracing/references/root-span-previews.md
+++ b/instrumenting-with-mlflow-tracing/references/root-span-previews.md
@@ -4,9 +4,9 @@ Use this pattern only when the root span's input or output is not already readab
 
 For other shapes, such as an agent state dict, the default preview is a serialized object that can be hard to scan. The UI truncates long strings itself, so keep the useful value intact rather than adding an arbitrary slice in application code.
 
-## Keep the decorator and set a trace-list preview
+## Set clean inputs/outputs preview for trace list UI
 
-Use `span.set_inputs()` when you want compact stored inputs. Use `update_current_trace()` when only the trace list needs a readable request or response preview; the decorated function can still return the full state.
+Use `update_current_trace()` when only the trace list needs a readable request or response preview.
 
 ```python
 import mlflow
@@ -14,9 +14,6 @@ from mlflow.entities import SpanType
 
 @mlflow.trace(span_type=SpanType.AGENT)
 def run_agent(graph, customer: str, date: str) -> dict:
-    span = mlflow.get_current_active_span()
-    span.set_inputs({"customer": customer, "date": date})
-
     state = graph.invoke({"customer": customer, "date": date})
     output_path = state.get("output_path", "")
     preview = state.get("note_text") or ""
@@ -25,9 +22,8 @@ def run_agent(graph, customer: str, date: str) -> dict:
         response_preview=f"output_path={output_path}, preview={preview}",
     )
     return state
-```
 
-## Store compact inputs and outputs on the root span
+## Override span inputs and outputs with compact values
 
 Keep the decorator when the function must return full state but the root span should store compact inputs or outputs. Explicit `span.set_inputs()` and `span.set_outputs()` values take precedence over the decorator's automatic capture.
 


### PR DESCRIPTION
Fixes #29

## Summary

When a coding agent used the MLflow instrumentation skills to trace a LangGraph agent, the top of the trace showed an unreadable blob instead of the run inputs and outputs. The \`@mlflow.trace\` decorator on the entry point auto-recorded the compiled LangGraph object as the request and the entire final state dict as the response. The root span showed neither the customer name going in nor the note coming out.

## Steps to reproduce

1. Ask a coding agent to instrument a LangGraph agent's entry point with \`@mlflow.trace\` per the skills.
2. Run the agent, open the trace, look at the root span request and response.

## Actual behavior

The root-span request was the Python repr of the compiled graph object. The root-span response was the full accumulated state dictionary (transcript plus all research plus draft). Both were unreadable in the UI.

## Root cause

The skill applied \`@mlflow.trace\` to a function whose input is a large framework object and whose output is a large state dict, without guiding the agent to record a compact, human-readable summary instead.

## Expected behavior and fix

The MLflow instrumentation skills should teach the coding agent to set a compact, readable request and response on the root span, rather than letting \`@mlflow.trace\` capture raw framework objects. For a LangGraph agent, that means the meaningful inputs (customer and date) and the meaningful outputs (output path and a short preview). The goal is that the trace reads well in the UI by default.

## Test setup

Verified on: MLflow 3.14.0, LangGraph 1.2.7, LangChain 1.3.11, databricks-langchain 0.17.0, Python 3.12.