### PR TITLE
Add a Prompt Registry discoverability step to mlflow-onboarding

### DIFF
--- a/mlflow-onboarding/SKILL.md
+++ b/mlflow-onboarding/SKILL.md
@@ -164,6 +164,32 @@ mock_chat("What is MLflow?")
 
 **Where to add it:** Find the application's entry point or initialization module and add the autologging call there. Search for the main LLM client instantiation (e.g., `openai.OpenAI()`, `ChatOpenAI()`) to find the right location.
 
+4. **Prompt Registry** (Unity Catalog only) — To register and load versioned prompts, the workspace must have the Prompt Registry preview enabled (account admin → Previews → "Prompt Registry").
+
+   ```python
+   import mlflow
+
+   # Register a prompt under a UC catalog.schema
+   prompt_version = mlflow.genai.register_prompt(
+       name="catalog.schema.my_prompt",
+       template="Answer the user's question: {{question}}",
+   )
+   # register_prompt logs a workspace UI link on success and auto-links
+   # the active experiment's Prompts tab to catalog.schema.
+
+   # Use the URI to load this prompt version in subsequent code
+   print(prompt_version.uri)  # prompts:/catalog.schema.my_prompt/1
+   ```
+
+   If the experiment's Prompts tab is empty after registering, the active experiment was not auto-linked (older mlflow versions do not set this tag automatically). Set it manually:
+
+   ```python
+   mlflow.set_experiment_tag(
+       "mlflow.promptRegistryLocation",
+       "catalog.schema",  # two-part: catalog.schema (no prompt name)
+   )
+   ```
+
 ### Traditional ML Integration
 
 The core integration for ML is **experiment tracking** — capturing parameters, metrics, and models from training runs.

--- a/mlflow-onboarding/SKILL.md
+++ b/mlflow-onboarding/SKILL.md
@@ -164,24 +164,23 @@ mock_chat("What is MLflow?")
 
 **Where to add it:** Find the application's entry point or initialization module and add the autologging call there. Search for the main LLM client instantiation (e.g., `openai.OpenAI()`, `ChatOpenAI()`) to find the right location.
 
-4. **Prompt Registry** (Unity Catalog only) — To register and load versioned prompts, the workspace must have the Prompt Registry preview enabled (account admin → Previews → "Prompt Registry").
+4. **Prompt Registry** (optional) — MLflow can version, store, and load prompts so application code loads a prompt by URI instead of hard-coding the template.
 
    ```python
    import mlflow
 
-   # Register a prompt under a UC catalog.schema
+   # Register a prompt version
    prompt_version = mlflow.genai.register_prompt(
-       name="catalog.schema.my_prompt",
+       name="my_prompt",
        template="Answer the user's question: {{question}}",
    )
-   # register_prompt logs a workspace UI link on success and auto-links
-   # the active experiment's Prompts tab to catalog.schema.
+   print(prompt_version.uri)  # prompts:/my_prompt/1
 
-   # Use the URI to load this prompt version in subsequent code
-   print(prompt_version.uri)  # prompts:/catalog.schema.my_prompt/1
+   # Load it back in application code
+   prompt = mlflow.genai.load_prompt("prompts:/my_prompt/1")
    ```
 
-   If the experiment's Prompts tab is empty after registering, the active experiment was not auto-linked (older mlflow versions do not set this tag automatically). Set it manually:
+   **On Databricks (Unity Catalog):** prompts are stored under a UC `catalog.schema`, so `name` is a three-part `catalog.schema.my_prompt` and the workspace must have the Prompt Registry preview enabled (account admin -> Previews -> "Prompt Registry"). On success `register_prompt` logs a workspace UI link and auto-links the active experiment's Prompts tab to `catalog.schema`. If that tab is empty after registering, the active experiment was not auto-linked (older mlflow versions do not set this tag automatically). Set it manually:
 
    ```python
    mlflow.set_experiment_tag(


### PR DESCRIPTION
## Summary

No step in `mlflow-onboarding` covered how to register a Unity Catalog-backed prompt with `mlflow.genai.register_prompt` or how to make registered prompts discoverable in the MLflow UI.

A user following the existing onboarding skill would register a prompt successfully but find:
- No UI link returned or logged
- The experiment's Prompts tab empty
- The schema picker showing "nothing to select"

The root cause is that the Prompts tab requires the `mlflow.promptRegistryLocation` experiment tag to be set, and nothing in the skill mentioned this. Recent mlflow versions set this tag automatically during `register_prompt`, but the skill gave no guidance on this behavior or the manual fallback for older versions.

## Changes

Added step 4 ("Prompt Registry") to the GenAI Integration section of `mlflow-onboarding/SKILL.md`:

- Notes that the workspace Prompt Registry preview must be enabled (account admin → Previews) for the UI to show prompts
- Shows `mlflow.genai.register_prompt(name="catalog.schema.my_prompt", template=...)` for a UC-backed prompt
- Notes that `register_prompt` logs a UI link on success and auto-links the active experiment's Prompts tab to the schema (via the `mlflow.promptRegistryLocation` tag) on recent mlflow versions
- Shows `prompt_version.uri` (`prompts:/catalog.schema.my_prompt/1`) as the programmatic handle to load the prompt later
- Includes a fallback for older mlflow: if the Prompts tab is empty, set `mlflow.promptRegistryLocation` manually with `mlflow.set_experiment_tag`
