### PR TITLE
Add build-a-judge skill for designing MLflow scorer suites

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   "skills": [
     "./mlflow-agent",
     "./agent-evaluation",
-    "./build-a-judge",
+    "./build-a-scorer",
     "./instrumenting-with-mlflow-tracing",
     "./analyze-mlflow-trace",
     "./analyze-mlflow-chat-session",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
   "skills": [
     "./mlflow-agent",
     "./agent-evaluation",
+    "./build-a-judge",
     "./instrumenting-with-mlflow-tracing",
     "./analyze-mlflow-trace",
     "./analyze-mlflow-chat-session",

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Building production-ready AI agents is hard. You need observability to understan
 | Skill | Description |
 |-------|-------------|
 | **agent-evaluation** | End-to-end agent evaluation workflow — dataset creation, scorer selection, evaluation execution, and results analysis. |
+| **build-a-judge** | Designs a small, cheap-to-run scorer suite from scratch — elicits quality criteria with you, routes each to code checks, built-in scorers, or LLM judges, then ships the implementation. |
 | **querying-mlflow-metrics** | Fetches aggregated metrics (token usage, latency, error rates) with time-series analysis and dimensional breakdowns. |
 
 ### Helping New Users

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Building production-ready AI agents is hard. You need observability to understan
 | Skill | Description |
 |-------|-------------|
 | **agent-evaluation** | End-to-end agent evaluation workflow — dataset creation, scorer selection, evaluation execution, and results analysis. |
-| **build-a-judge** | Designs a small, cheap-to-run scorer suite from scratch — elicits quality criteria with you, routes each to code checks, built-in scorers, or LLM judges, then ships the implementation. |
+| **build-a-scorer** | Designs a small, cheap-to-run scorer suite from scratch — elicits quality criteria with you, routes each to code checks, built-in scorers, or LLM judges, then ships the implementation. |
 | **querying-mlflow-metrics** | Fetches aggregated metrics (token usage, latency, error rates) with time-series analysis and dimensional breakdowns. |
 
 ### Helping New Users

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -38,14 +38,14 @@ If you're tempted to create `evaluation/eval_dataset.py` or similar custom files
 **Evaluation workflow in 5 steps** (each uses MLflow APIs):
 
 1. **Understand**: Run agent, inspect traces, understand purpose
-2. **Scorers**: Register the agreed scorer suite (use `build-a-judge` first if it does not exist yet)
+2. **Scorers**: Register the agreed scorer suite (use `build-a-scorer` first if it does not exist yet)
 3. **Dataset**: ALWAYS discover existing datasets first, only create new if needed
 3.5. **Dry Run**: Run 3 questions first — catch broken tools and misconfigured scorers before full eval
 4. **Evaluate**: Run agent on dataset, apply scorers, analyze results
 
 **Scope boundary:** this skill owns *running* evaluation — registration, datasets, execution, and
 analysis. Designing the scorer suite (which criteria, and code check vs. built-in vs. LLM judge) is
-the `build-a-judge` skill's job. The seam is a confirmed suite of criteria with an implementation
+the `build-a-scorer` skill's job. The seam is a confirmed suite of criteria with an implementation
 chosen for each.
 
 ## Command Conventions
@@ -166,20 +166,20 @@ Before doing anything else, ask the user these questions. Do NOT proceed until y
 - Write the `agent_description` parameter for `generate_evals_df`
 - Set evaluation priorities
 - Decide whether the quality criteria are already clear (continue to Step 2) or still need to be
-  worked out with the user (use the `build-a-judge` skill — see Step 2)
+  worked out with the user (use the `build-a-scorer` skill — see Step 2)
 
 **If running in automated mode:** Read agent purpose from the codebase (SKILL.md, README, or main entry point docstring). Still surface what you found and confirm before proceeding.
 
 **Scope note:** these three questions establish *what the agent is*. They are not enough to design a
 scorer suite. If the answers to (2) and (3) are vague — "good answers", "it should be accurate" — do
-not invent scorer names from them; that is what `build-a-judge` is for.
+not invent scorer names from them; that is what `build-a-scorer` is for.
 
 ### Step 2: Register Quality Scorers
 
 This step **registers and runs** scorers. Designing them — which criteria matter, and whether each is
-cheapest as a code check, a built-in, or an LLM judge — belongs to the `build-a-judge` skill.
+cheapest as a code check, a built-in, or an LLM judge — belongs to the `build-a-scorer` skill.
 
-> 💡 **If the user does not already have a scorer suite, use the `build-a-judge` skill first.**
+> 💡 **If the user does not already have a scorer suite, use the `build-a-scorer` skill first.**
 > It returns a confirmed set of 3-5 atomic criteria, each with an implementation chosen per criterion
 > (code check, built-in, or `make_judge`) and an output type that survives aggregation. Come back here
 > to register and run them.
@@ -202,7 +202,7 @@ See `references/scorers.md` for the built-in scorers. Add any that the suite cal
 
 Implement the remaining criteria with `make_judge()` (LLM judges) or `@scorer` (deterministic code checks). See `references/scorers.md` for the APIs and `references/scorers-constraints.md` for constraints that silently break results.
 
-If you are inventing criteria at this point rather than implementing agreed ones, stop and use `build-a-judge` — a scorer whose criterion the user has not confirmed will not survive validation.
+If you are inventing criteria at this point rather than implementing agreed ones, stop and use `build-a-scorer` — a scorer whose criterion the user has not confirmed will not survive validation.
 
 > ⚠️ **CRITICAL — Scorer Return Values:** Scorers MUST instruct the LLM judge to return `"yes"` or `"no"` (or booleans/numerics). Return values of `"pass"` or `"fail"` are **silently cast to `None`** by `_cast_assessment_value_to_float` and **excluded from `results.metrics`** with no error or warning — results simply disappear. See `references/scorers-constraints.md` Constraint 2 for the full list of safe vs. broken return values.
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -38,10 +38,15 @@ If you're tempted to create `evaluation/eval_dataset.py` or similar custom files
 **Evaluation workflow in 5 steps** (each uses MLflow APIs):
 
 1. **Understand**: Run agent, inspect traces, understand purpose
-2. **Scorers**: Select and register scorers for quality criteria
+2. **Scorers**: Register the agreed scorer suite (use `build-a-judge` first if it does not exist yet)
 3. **Dataset**: ALWAYS discover existing datasets first, only create new if needed
 3.5. **Dry Run**: Run 3 questions first — catch broken tools and misconfigured scorers before full eval
 4. **Evaluate**: Run agent on dataset, apply scorers, analyze results
+
+**Scope boundary:** this skill owns *running* evaluation — registration, datasets, execution, and
+analysis. Designing the scorer suite (which criteria, and code check vs. built-in vs. LLM judge) is
+the `build-a-judge` skill's job. The seam is a confirmed suite of criteria with an implementation
+chosen for each.
 
 ## Command Conventions
 
@@ -158,20 +163,29 @@ Before doing anything else, ask the user these questions. Do NOT proceed until y
 3. "Are there common failure modes you've already noticed?"
 
 **Use answers to:**
-- Derive scorer names and criteria (do not invent them)
 - Write the `agent_description` parameter for `generate_evals_df`
 - Set evaluation priorities
+- Decide whether the quality criteria are already clear (continue to Step 2) or still need to be
+  worked out with the user (use the `build-a-judge` skill — see Step 2)
 
 **If running in automated mode:** Read agent purpose from the codebase (SKILL.md, README, or main entry point docstring). Still surface what you found and confirm before proceeding.
 
-### Step 2: Define Quality Scorers
+**Scope note:** these three questions establish *what the agent is*. They are not enough to design a
+scorer suite. If the answers to (2) and (3) are vague — "good answers", "it should be accurate" — do
+not invent scorer names from them; that is what `build-a-judge` is for.
 
-> 💡 **If the user does not yet know what to measure, use the `build-a-judge` skill for this step.**
-> Deciding *which* criteria matter — and whether each is cheapest as a code check, a built-in, or an
-> LLM judge — is the hardest part of evaluation and has its own workflow. `build-a-judge` returns a
-> confirmed suite of 3-5 atomic criteria with an implementation chosen per criterion; come back here
-> to register them and run the evaluation. Skip it when the criteria are already clear, or when
-> scorers are already registered in the experiment.
+### Step 2: Register Quality Scorers
+
+This step **registers and runs** scorers. Designing them — which criteria matter, and whether each is
+cheapest as a code check, a built-in, or an LLM judge — belongs to the `build-a-judge` skill.
+
+> 💡 **If the user does not already have a scorer suite, use the `build-a-judge` skill first.**
+> It returns a confirmed set of 3-5 atomic criteria, each with an implementation chosen per criterion
+> (code check, built-in, or `make_judge`) and an output type that survives aggregation. Come back here
+> to register and run them.
+>
+> Go straight to registration below when scorers are already registered in the experiment, or the user
+> hands you an explicit list of criteria and implementations.
 
 1. **Check registered scorers in your experiment:**
    ```bash
@@ -180,13 +194,15 @@ Before doing anything else, ask the user these questions. Do NOT proceed until y
 
 **IMPORTANT: if there are registered scorers in the experiment then they must be used for evaluation.**
 
-2. **Select additional built-in scorers that apply to the agent** 
+2. **Add the built-in scorers from the agreed suite**
 
-See `references/scorers.md` for the built-in scorers. Select any that are useful for assessing the agent's quality and that are not already registered. 
+See `references/scorers.md` for the built-in scorers. Add any that the suite calls for and that are not already registered.
 
-3. **Create additional custom scorers as needed**
+3. **Add the custom scorers from the agreed suite**
 
-If needed, create additional scorers using the `make_judge()` API. See `references/scorers.md` on how to create custom scorers and `references/scorers-constraints.md` for best practices.
+Implement the remaining criteria with `make_judge()` (LLM judges) or `@scorer` (deterministic code checks). See `references/scorers.md` for the APIs and `references/scorers-constraints.md` for constraints that silently break results.
+
+If you are inventing criteria at this point rather than implementing agreed ones, stop and use `build-a-judge` — a scorer whose criterion the user has not confirmed will not survive validation.
 
 > ⚠️ **CRITICAL — Scorer Return Values:** Scorers MUST instruct the LLM judge to return `"yes"` or `"no"` (or booleans/numerics). Return values of `"pass"` or `"fail"` are **silently cast to `None`** by `_cast_assessment_value_to_float` and **excluded from `results.metrics`** with no error or warning — results simply disappear. See `references/scorers-constraints.md` Constraint 2 for the full list of safe vs. broken return values.
 

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -166,6 +166,13 @@ Before doing anything else, ask the user these questions. Do NOT proceed until y
 
 ### Step 2: Define Quality Scorers
 
+> 💡 **If the user does not yet know what to measure, use the `build-a-judge` skill for this step.**
+> Deciding *which* criteria matter — and whether each is cheapest as a code check, a built-in, or an
+> LLM judge — is the hardest part of evaluation and has its own workflow. `build-a-judge` returns a
+> confirmed suite of 3-5 atomic criteria with an implementation chosen per criterion; come back here
+> to register them and run the evaluation. Skip it when the criteria are already clear, or when
+> scorers are already registered in the experiment.
+
 1. **Check registered scorers in your experiment:**
    ```bash
    uv run mlflow scorers list -x $MLFLOW_EXPERIMENT_ID

--- a/build-a-judge/SKILL.md
+++ b/build-a-judge/SKILL.md
@@ -196,13 +196,26 @@ on them, but do not act as though the catalog is empty:
 | `Retrieval{Groundedness,Relevance,Sufficiency}` | inputs, trace | **RETRIEVER spans only** — see Phase 2 |
 | `UserFrustration`, `ConversationCompleteness`, `KnowledgeRetention`, `ConversationalSafety`, `ConversationalRoleAdherence` | none (session-level) | multi-turn outcome and conversation quality |
 
-A hand-written judge is unversioned, unaligned, and untested; a built-in is maintained upstream.
-Prefer `Guidelines` over a bespoke `make_judge` for policy-adherence phrasing.
+**A built-in is a better starting point than a blank prompt — not a substitute for your standard.**
+Built-ins are LLM judges too: they carry MLflow's generic `instructions` for a generic notion of
+relevance or safety. Prefer them because the scaffolding and data contract are already tested, not
+because "built-in" implies correct for your product. Anywhere your bar differs from the industry
+default, say so and expect to align or replace.
 
-**"My domain is too specific" is not a reason to skip built-ins.** `Guidelines` takes *your* policy
-text, so domain specificity is an argument *for* it. Session-level built-ins
-(`UserFrustration`, `ConversationCompleteness`) measure conversation quality independent of domain.
-Even in a specialised suite, expect at least one built-in unless you can name why each was unusable.
+Two consequences worth stating to the user:
+
+- **`Guidelines` is the exception that always applies.** It takes *your* policy text, so there is no
+  imported standard — domain specificity is an argument *for* it, not against.
+- **Alignment cuts across the built-in/bespoke line.** `align(traces=...)` is on `Judge`, so
+  single-turn built-ins (`RelevanceToQuery`, `Safety`, `Correctness`, `PIIDetection`) can be aligned
+  to your labels just like `make_judge`. Session-level built-ins (`UserFrustration`,
+  `ConversationCompleteness`, `KnowledgeRetention`) **raise `NotImplementedError` on `align()`** —
+  they are permanently stuck on MLflow's definition. Use them for a cheap first signal, and flag
+  that they cannot be tuned; if the criterion is important and contested, hand-write it so it can be
+  aligned.
+
+Skipping built-ins is legitimate when your standard genuinely differs. Skipping them without
+looking is not.
 
 Default routes:
 
@@ -289,25 +302,35 @@ Only after confirmation. Deliver **one consolidated final message**, not code sp
   Always add: "Once traces and human labels come in, align this judge and validate agreement before
   relying on it for monitoring."
 
-### Phase 8: Validate before scaling
+### Phase 8: Name the validation plan, then hand off
+
+Decide *how the suite will be judged* — then stop. Running the evaluation is `agent-evaluation`'s
+job, and this skill must not duplicate it.
 
 **Lead with labels the user already has.** Before proposing anyone hand-label a fresh dataset, ask
 what past failures are already recorded — support tickets, complaints, incident reports,
 thumbs-down feedback, refunds, escalations. Backtesting against real known-bad cases beats synthetic
 labels and costs nothing to produce. Propose hand-labeling only if no such history exists.
 
-Then: run v1 on 5-20 examples, inspect disagreements manually, fix code checks or judge wording,
-keep only stable checks, and schedule production monitoring once the suite is useful. Be cautious
-aligning subjective axes like tone or style — alignment can overfit.
+For each LLM judge, state the alignment plan: which labels it will be aligned against, and that its
+first version is a draft. Be cautious aligning subjective axes like tone or style — alignment can
+overfit. Note where alignment is impossible: session-level built-ins raise `NotImplementedError`.
 
-Close with the suite, parked v2 ideas, trace-only upgrades, the first command to run, and the
-alignment reminder for every LLM judge.
+Close with the confirmed suite, the implementation, parked v2 ideas, trace-only upgrades, and the
+validation plan.
 
-**Then hand off.** This skill designs the suite; it does not own the evaluation pipeline. Point the
-user at the `agent-evaluation` skill to register the scorers, build or discover a dataset, dry-run,
-execute, and analyze results. Registration matters: unregistered inline scorers will not appear in
-`mlflow scorers list` and are not reusable. For tracing gaps surfaced in Phase 2 — missing spans, a
-lookup instrumented as `TOOL` rather than `RETRIEVER` — point at `instrumenting-with-mlflow-tracing`.
+**Then hand off — do not run the evaluation yourself.**
+
+- `agent-evaluation` — registering scorers, dataset discovery/creation, dry run, full evaluation,
+  results analysis, and iteration. Registration matters: unregistered inline scorers do not appear in
+  `mlflow scorers list` and are not reusable.
+- `instrumenting-with-mlflow-tracing` — tracing gaps surfaced in Phase 2, such as a lookup
+  instrumented as `TOOL` when a criterion needs `RETRIEVER`.
+
+> **Scope boundary.** This skill decides *what to measure and how to implement it*.
+> `agent-evaluation` decides *how to run it and what the results mean*. If you find yourself
+> preparing a dataset, registering scorers, or interpreting eval output, you have left this skill's
+> scope — hand off instead.
 
 ## Anti-patterns
 

--- a/build-a-judge/SKILL.md
+++ b/build-a-judge/SKILL.md
@@ -1,0 +1,333 @@
+---
+name: build-a-judge
+description: Help the user go from zero to a shipped MLflow evaluation prototype by understanding their app, generalizing a small set of atomic quality criteria, and implementing each criterion with the cheapest reliable scorer. Use when the user wants help choosing, creating, or iterating MLflow judges/scorers for an agent, RAG app, LLM app, or GenAI workflow.
+allowed-tools: Read, Write, Bash, Grep, Glob
+---
+
+# build-a-judge
+
+Help the user get from **zero to shipped evaluation prototype**. Not 100% correctness on the first
+pass — a stable, understandable scorer suite they can run, inspect, and iterate on.
+
+Your primary job is **understanding**, and the user is the expert on what counts as wrong. Do not
+start from "which MLflow scorer should I use?"
+
+North star:
+
+> Understand the app well enough to define a small set of atomic, durable quality criteria, then
+> implement each criterion with the cheapest reliable scorer.
+
+## Doctrine
+
+1. **Prototype first.** Ship a useful v1 that runs now. Mark v2 upgrades explicitly.
+2. **Small suite.** 3-5 high-signal scorers, hard cap. Adding one means dropping a weaker one.
+3. **One scorer, one criterion.** If a criterion contains "and", split it. No "overall quality" judge.
+4. **Cheapest reliable implementation.** Code/rules beat built-ins beat hand-written LLM judges.
+   See Phase 4 — the rule most often skipped, and skipping it costs real money at scale.
+   Never hand-roll a judge for something MLflow already ships.
+5. **Cover outcomes, not just rules.** A suite of only policy checks tells you the agent behaved
+   while saying nothing about whether users succeeded. Every suite needs at least one check on
+   whether the user got what they came for. See Phase 3.
+6. **Binary outputs.** Prefer `bool`, or `"yes"`/`"no"` for LLM judges — other strings are silently
+   dropped from metrics (Phase 4). Avoid `0.0-1.0` without a calibration story; pass rates debug
+   better than averaged floats.
+7. **Traces are optional.** Inspect them if they exist; otherwise use dataset + `predict_fn`. Never
+   block the user on tracing unless the criterion truly needs execution internals.
+8. **Align later.** Treat every first LLM judge as a draft. Remind the user to align it once traces
+   and human labels arrive.
+9. **Talk before code.** The conversation is where right and wrong get settled. A large code block
+   ends it — users stop reading and start implementing. Small snippets mid-conversation are fine;
+   the full implementation goes in your final message, after the user confirms the criteria.
+
+## Source of truth: introspect, don't memorize
+
+MLflow's scorer surface changes. Before recommending scorers, read the installed surface (use
+`uv run python` in a uv-managed repo, plain `python` otherwise):
+
+```bash
+python -c "
+from mlflow.genai.scorers import get_all_scorers
+import mlflow.genai.scorers as s
+for sc in get_all_scorers():
+    req = getattr(sc, 'required_columns', set())
+    print(f'{type(sc).__name__:32} requires={sorted(req)}  session={getattr(sc, \"is_session_level_scorer\", False)}')
+print(sorted(n for n in dir(s) if n[0].isupper()))
+"
+```
+
+- `get_all_scorers()` returns built-ins instantiable with defaults. Constructor-arg scorers
+  (`Guidelines`, `RegexMatch`, `ResponseLength`) may only appear in exported names.
+- `.required_columns` is the exact data contract. Use it; never guess.
+- LLM judges: `from mlflow.genai.judges import make_judge`. Code scorers:
+  `from mlflow.genai.scorers import scorer`.
+
+If MLflow is not importable, say so, continue from first principles, and flag that names and
+required columns need verification.
+
+## User-facing language
+
+Product language first (**quality check**, **judge**, **code check**, **built-in check**), API
+language second (**scorer**, `make_judge`, `@scorer`, `required_columns`). State each recommendation as:
+
+```text
+Quality check: <plain-English name>     Layer: <rule | outcome>
+Criterion: <one sentence, one thing only>
+Implementation: <code check | built-in | LLM judge>
+Why not cheaper: <for LLM judges — the code check AND built-in you rejected, and why>
+Output: <bool, or "yes"/"no">          Data needed: <inputs/outputs/expectations/trace/session>
+```
+
+## The workflow
+
+### Phase 0: Orient
+
+State the working agreement plainly:
+
+> We'll build a small v1 scorer suite that runs now, catches repeated failures, and gives you a
+> stable base to iterate. It will not be perfect yet.
+
+### Phase 1: Elicit the user's notion of right and wrong
+
+Your job is **criteria, not architecture** — what the user thinks good and bad look like, not their
+product spec.
+
+**Ask at most 3 questions before showing a draft.** Users correct a wrong draft far more easily than
+they answer an interview.
+
+Open with these, one at a time:
+
+1. What does the app do?
+2. What is the worst failure you could ship?
+3. What should it do when it is unsure or lacks information?
+
+Then stop asking and draft. Translate vague answers like "good responses" into named observable
+criteria **yourself** and show them for correction — do not bounce the work back as another question.
+
+Out of scope; these are the user's job, not the judge's:
+
+- Which fields are required at which step of their business logic.
+- How the app decides between branches or states.
+- Internal schemas, gates, thresholds, or slot taxonomies.
+
+If you catch yourself asking a second consecutive question about app internals, stop and draft.
+
+**Real failure to avoid:** eliciting "it shouldn't book if information is incomplete", then asking
+four follow-ups about which fields count as complete. The first sentence was already enough.
+
+### Phase 2: Check what is observable
+
+Once the user has reacted to a draft, establish what evidence a judge can actually see. A criterion
+is only real if it is checkable. One focused pass, not an interview.
+
+If traces exist, inspect one or two: confirm `inputs`, `outputs`, `expectations`, span types, tool
+calls, and whether the task is single-turn or session-level.
+
+**The RETRIEVER-vs-TOOL trap:** `RetrievalGroundedness`, `RetrievalRelevance`, and
+`RetrievalSufficiency` require `RETRIEVER` spans and **hard-raise** otherwise. A `web_search` or DB
+lookup instrumented as `TOOL` does not qualify. For "grounded in tool output", use a trace-based
+`make_judge` with `{{ trace }}` or a code scorer over tool outputs.
+
+If traces do not exist, use `inputs` + optional `outputs`/`expectations` with
+`mlflow.genai.evaluate(data=..., predict_fn=..., scorers=[...])`, and mark trace-only upgrades as
+future work.
+
+### Phase 3: Generalize into atomic criteria — across both layers
+
+Cluster examples into repeated failure modes. Keep criteria likely to recur; park one-off oddities.
+Name them like `answers_user_question`, `does_not_invent_facts`, `refuses_out_of_scope_requests` —
+one behavior each.
+
+**Cover two layers. Suites that only do the first layer are the most common failure of this skill.**
+
+1. **Rule layer — did the agent misbehave on this turn?** Policy violations, wrong facts, missed
+   escalations, forbidden claims. Easy to name, easy to check, and where users' stated fears live.
+2. **Outcome layer — did the user get what they came for?** Task completion, abandonment,
+   frustration, having to repeat themselves. Harder to name, and the reason the product exists.
+
+An agent can pass every rule check and still be useless. Ask directly: *"What does success look
+like for the user — what did they come here to do, and how would we know they did it?"*
+
+Outcome checks are often **cheap**, not expensive — do not assume they need an LLM judge:
+
+- `task_completed` — did the trace contain the goal tool call (booking, application, order)? Code.
+- Session-level built-ins with no data requirements: `UserFrustration`,
+  `ConversationCompleteness`, `KnowledgeRetention`. Verify with `.required_columns`.
+- `had_to_repeat` — did the user restate the same request across turns? Code over the conversation.
+
+**Do not substitute a checkable proxy for the outcome that matters.** A check like
+`promotion_disclosed` ("was a promo flag mentioned?") looks rigorous but measures text presence, not
+whether the renter got the best deal or felt well-served. Proxies are fine as *rule* checks; they do
+not discharge the outcome layer. If the user's real goal is fuzzy, say so and pair a cheap proxy with
+one honest outcome check rather than pretending the proxy covers it.
+
+Keep outcome checks atomic too. "Meets customer expectation" bundles found-what-they-wanted,
+wasn't-misled, and wasn't-frustrated; when it fails you learn nothing. Split it.
+
+### Phase 4: Route each criterion to the cheapest reliable implementation
+
+Do this **before** asking the user to confirm the suite, so they are approving real cost.
+
+```text
+Can code check it deterministically (or filter most cases)?
+  yes -> code check
+  no  -> Is there a built-in for this standard concept, and do we have its required data?
+          yes -> built-in
+          no  -> LLM judge
+```
+
+**Checkpoint — every hand-written LLM judge needs a `why not cheaper` cell naming both the code
+check and the built-in you rejected.** Not prose elsewhere in the message: the cell in the Phase 6
+table. If you cannot fill it, the check is miscategorized. "No built-in covers this" counts only if
+you actually looked.
+
+**Check the catalog before hand-rolling.** Run the introspection command above when MLflow is
+importable; when it is not, these ship today — confirm names and `required_columns` before relying
+on them, but do not act as though the catalog is empty:
+
+| Built-in | Requires | Use for |
+|---|---|---|
+| `Guidelines(guidelines=...)` | inputs, outputs | "does the response follow this stated policy" — the most under-used built-in |
+| `Correctness` | inputs, outputs | answer matches expected |
+| `RelevanceToQuery` | inputs, outputs | response addresses the question |
+| `Safety` / `PIIDetection` | inputs, outputs / outputs | harmful content; PII leakage |
+| `RegexMatch(pattern=...)` / `ResponseLength(...)` | outputs | pattern and length rules |
+| `Completeness` / `Fluency` / `Summarization` | inputs, outputs | coverage; readability; summary quality |
+| `ToolCallCorrectness` / `ToolCallEfficiency` | trace | right tools, no redundant calls |
+| `Retrieval{Groundedness,Relevance,Sufficiency}` | inputs, trace | **RETRIEVER spans only** — see Phase 2 |
+| `UserFrustration`, `ConversationCompleteness`, `KnowledgeRetention`, `ConversationalSafety`, `ConversationalRoleAdherence` | none (session-level) | multi-turn outcome and conversation quality |
+
+A hand-written judge is unversioned, unaligned, and untested; a built-in is maintained upstream.
+Prefer `Guidelines` over a bespoke `make_judge` for policy-adherence phrasing.
+
+**"My domain is too specific" is not a reason to skip built-ins.** `Guidelines` takes *your* policy
+text, so domain specificity is an argument *for* it. Session-level built-ins
+(`UserFrustration`, `ConversationCompleteness`) measure conversation quality independent of domain.
+Even in a specialised suite, expect at least one built-in unless you can name why each was unusable.
+
+Default routes:
+
+- Format, JSON shape, required field, regex/link, length, exact value, latency, PII pattern,
+  **specific phrases or keywords**: code check.
+- Relevance, correctness, safety, groundedness, retrieval quality, tool-call quality, fluency,
+  session-level conversation quality: built-in, if the data contract matches.
+- Domain tone, policy adherence, task-specific correctness, paraphrase-matching against a source,
+  nuanced refusal quality: LLM judge.
+
+**Prefer a hybrid over a pure judge.** Most "semantic" checks have a cheap deterministic front end:
+a keyword or phrase scan catches the bright-line cases at ~zero cost and passes only ambiguous ones
+to a model. Reach for this whenever a criterion mentions specific commitments, categories, or
+trigger topics — "did it promise a refund", "did the user raise a billing dispute". Detecting the
+*trigger* is usually code; judging the *response* may need a model.
+
+Push back when the user reaches for an LLM judge to count words or validate JSON, a regex to judge
+tone, one "overall good" scorer, or a float without a calibration reason.
+
+**Output types — only `bool`, numerics, and `"yes"`/`"no"` aggregate.** Anything else is silently
+cast to `None` by `_cast_assessment_value_to_float` and **dropped from `results.metrics`** with no
+error: `"pass"`, `"fail"`, `"correct"`, `"not_applicable"` all disappear. Verified against
+`mlflow/genai/scorers/aggregation.py`; `CategoricalRating` accepts only `yes`/`no`/`unknown`.
+
+- Prefer `bool` for pass/fail.
+- Use `"yes"`/`"no"` when an LLM judge must return a string.
+- Represent "criterion does not apply" as `Feedback(value=True, rationale="not applicable: ...")`,
+  or skip the row — not as a `"not_applicable"` string, which vanishes from the metrics.
+- Put extra detail in `rationale`, not in the value.
+
+### Phase 5: Sharpen each criterion with the domain expert
+
+**This is the highest-value phase — spend most of the conversation here.** The user is the expert on
+what counts as wrong. Your job is to find each criterion's **edge**: where a reasonable person could
+call the same behavior acceptable or unacceptable.
+
+**Propose, don't interrogate.** Put candidate verdicts in front of the user and let them rule:
+
+> For "does not steer by protected class" — I'd fail these three: [...]. I'd pass this one because
+> the renter asked first: [...]. I'm unsure about this one: [...]. Where do you draw it?
+
+This yields far more signal per turn than open questions, and costs the user a judgment call rather
+than a specification.
+
+Probes, each carrying your own proposed answer:
+
+- **Near-miss.** "Would you fail this one, almost identical but [X]?"
+- **Legitimate exception.** "Is there a case where this behavior is actually correct?"
+- **Severity split.** "Is one of these a red line and the other a papercut?"
+- **Not-applicable.** "What should the check say when the criterion doesn't apply?"
+
+A criterion is done when the user has corrected or confirmed at least one proposed verdict, two
+people would label the same example the same way, and you know what "not applicable" looks like.
+
+Small snippets help here — an output shape, a three-item keyword list. Full implementations do not.
+
+### Phase 6: Confirm before implementing
+
+Restate the suite as a **table**, one row per check, with these columns filled in for every row:
+name | layer (rule/outcome) | implementation | why not cheaper | output. A blank cell is a design
+hole, not a formatting choice — an LLM judge with no "why not cheaper" is unroutable, and a suite
+with no outcome row is incomplete. Then **ask the user to confirm or change it** and wait.
+
+> Here's the suite I'd build. Anything to add, drop, or reword before I write it?
+
+**Enforce the size cap here.** If you have more than 5 checks, do not ask the user to prune — say
+which you would drop and why, then let them overrule you. Adding a criterion means replacing a
+weaker one, not growing the list. A 9-check v1 is a checklist, and checklists do not get validated.
+
+Do not write the full implementation on the same turn as the confirmation request. If anything
+changes, re-confirm the changed items.
+
+### Phase 7: Deliver the implementation
+
+Only after confirmation. Deliver **one consolidated final message**, not code spread across turns.
+
+- Code checks: runnable, with imports, malformed-input guards, and a runnable
+  `mlflow.genai.evaluate(...)` call.
+- Built-ins: state the data contract from `.required_columns`. If the data is absent, re-route or
+  mark as a future upgrade.
+- LLM judges: give the actual `instructions` string tailored to their domain, with template
+  variables (`{{ inputs }}`, `{{ outputs }}`, `{{ expectations }}`, `{{ trace }}`,
+  `{{ conversation }}`), a `bool` or `"yes"`/`"no"` output, model choice, and cost at their stated volume.
+  Always add: "Once traces and human labels come in, align this judge and validate agreement before
+  relying on it for monitoring."
+
+### Phase 8: Validate before scaling
+
+**Lead with labels the user already has.** Before proposing anyone hand-label a fresh dataset, ask
+what past failures are already recorded — support tickets, complaints, incident reports,
+thumbs-down feedback, refunds, escalations. Backtesting against real known-bad cases beats synthetic
+labels and costs nothing to produce. Propose hand-labeling only if no such history exists.
+
+Then: run v1 on 5-20 examples, inspect disagreements manually, fix code checks or judge wording,
+keep only stable checks, and schedule production monitoring once the suite is useful. Be cautious
+aligning subjective axes like tone or style — alignment can overfit.
+
+Close with the suite, parked v2 ideas, trace-only upgrades, the first command to run, and the
+alignment reminder for every LLM judge.
+
+**Then hand off.** This skill designs the suite; it does not own the evaluation pipeline. Point the
+user at the `agent-evaluation` skill to register the scorers, build or discover a dataset, dry-run,
+execute, and analyze results. Registration matters: unregistered inline scorers will not appear in
+`mlflow scorers list` and are not reusable. For tracing gaps surfaced in Phase 2 — missing spans, a
+lookup instrumented as `TOOL` rather than `RETRIEVER` — point at `instrumenting-with-mlflow-tracing`.
+
+## Anti-patterns
+
+- Starting from the scorer catalog instead of the user's app and failures.
+- Writing code before the user agreed to named criteria. If they ask to talk, talk.
+- Dumping a large code block mid-conversation; it ends the sharpening discussion.
+- Shipping a suite of all-LLM judges without stating why each one can't be a code check or built-in
+  — the most common and most expensive failure of this skill.
+- Hand-rolling a `make_judge` for something MLflow ships. Policy adherence is `Guidelines`;
+  pattern rules are `RegexMatch`; multi-turn quality has session-level built-ins.
+- Shipping only rule/policy checks with nothing measuring whether users succeeded. An agent can
+  pass every compliance check and still fail everyone who used it.
+- Substituting a checkable proxy for the outcome that matters (`promotion_disclosed` in place of
+  "the renter got the best available deal") and treating the outcome layer as covered.
+- Answering a cost objection with sampling alone when a cheaper implementation was available.
+- Proposing fresh hand-labeling before asking what labels the user already has.
+- Interviewing past 3 questions without showing a draft.
+- Asking about internal gates or state machines in order to write a judge.
+- Checking only the end state when the failure happened upstream in the conversation.
+- Blocking on traces when a dataset/`predict_fn` prototype would work.
+- Combining multiple criteria into one scorer, or scoring one-off examples that don't generalize.
+- `0.0-1.0` scores by default; code with undefined placeholders.
+- `RetrievalGroundedness` on TOOL-only traces.

--- a/build-a-judge/SKILL.md
+++ b/build-a-judge/SKILL.md
@@ -41,11 +41,11 @@ North star:
 
 ## Source of truth: introspect, don't memorize
 
-MLflow's scorer surface changes. Before recommending scorers, read the installed surface (use
-`uv run python` in a uv-managed repo, plain `python` otherwise):
+MLflow's scorer surface changes. Before recommending scorers, read the installed surface. Drop the
+`uv run` prefix if the project is not uv-managed:
 
 ```bash
-python -c "
+uv run python -c "
 from mlflow.genai.scorers import get_all_scorers
 import mlflow.genai.scorers as s
 for sc in get_all_scorers():

--- a/build-a-judge/SKILL.md
+++ b/build-a-judge/SKILL.md
@@ -124,8 +124,15 @@ calls, and whether the task is single-turn or session-level.
 
 **The RETRIEVER-vs-TOOL trap:** `RetrievalGroundedness`, `RetrievalRelevance`, and
 `RetrievalSufficiency` require `RETRIEVER` spans and **hard-raise** otherwise. A `web_search` or DB
-lookup instrumented as `TOOL` does not qualify. For "grounded in tool output", use a trace-based
-`make_judge` with `{{ trace }}` or a code scorer over tool outputs.
+lookup instrumented as `TOOL` does not qualify.
+
+For "grounded in tool output", **prefer a code scorer that extracts the tool output from the trace
+and passes just that to a judge, over handing the whole trace to `make_judge` with `{{ trace }}`.**
+A `{{ trace }}` judge re-reads the entire trace on every row: more tokens, more cost, and more
+nondeterminism, because the model has to locate the relevant span itself before judging it. Pulling
+the span in code is deterministic and free; only the comparison needs a model. Reach for
+`{{ trace }}` when the criterion is genuinely about the shape of the whole trace — tool sequencing,
+retry behaviour — rather than about one span's contents.
 
 If traces do not exist, use `inputs` + optional `outputs`/`expectations` with
 `mlflow.genai.evaluate(data=..., predict_fn=..., scorers=[...])`, and mark trace-only upgrades as
@@ -298,9 +305,20 @@ Only after confirmation. Deliver **one consolidated final message**, not code sp
   mark as a future upgrade.
 - LLM judges: give the actual `instructions` string tailored to their domain, with template
   variables (`{{ inputs }}`, `{{ outputs }}`, `{{ expectations }}`, `{{ trace }}`,
-  `{{ conversation }}`), a `bool` or `"yes"`/`"no"` output, model choice, and cost at their stated volume.
+  `{{ conversation }}`), a `bool` or `"yes"`/`"no"` output, and cost at their stated volume.
   Always add: "Once traces and human labels come in, align this judge and validate agreement before
   relying on it for monitoring."
+
+**Judge model selection.** Leave `model=None` unless the user has a reason to override it — MLflow
+picks the managed judge on a Databricks tracking URI, or `openai:/gpt-4.1-mini` otherwise. State the
+default you are relying on so the user can see it, and quote cost at their stated volume.
+
+- Start on a mid-tier model and only downgrade after checking agreement on a labelled sample. A
+  cheaper judge that disagrees with humans is more expensive than no judge.
+- Do not downgrade a judge guarding a red-line criterion (safety, legal, compliance) to save cents —
+  volume is usually low, because the code prefilter gates it.
+- `agent-evaluation/references/scorers.md` → "Model Selection for Scorers" is authoritative for
+  `model=` URIs, defaults, and API-key setup. Point there rather than restating it.
 
 ### Phase 8: Name the validation plan, then hand off
 

--- a/build-a-scorer/SKILL.md
+++ b/build-a-scorer/SKILL.md
@@ -126,24 +126,17 @@ calls, and whether the task is single-turn or session-level.
 `RetrievalSufficiency` require `RETRIEVER` spans and **hard-raise** otherwise. A `web_search` or DB
 lookup instrumented as `TOOL` does not qualify.
 
-For "grounded in tool output", **prefer a code scorer that extracts the relevant span and passes only
-that to a judge, over handing the whole trace to `make_judge` with `{{ trace }}`:**
+For "grounded in tool output", **prefer a code scorer that wraps a judge over a judge that takes
+`{{ trace }}`.** A `@scorer` function receives the `trace`, so it can call
+`trace.search_spans(span_type=SpanType.TOOL)` to pull out the one span holding the evidence, then pass
+just that span's output and the agent's claim to a `make_judge` judge whose instructions take two
+short strings. Code locates the evidence; the model only does the semantic comparison.
 
-```python
-# Preferred — code finds the evidence, the model only compares it.
-@scorer
-def grounded_in_lookup(trace, outputs) -> bool:
-    spans = trace.search_spans(span_type=SpanType.TOOL)   # deterministic, free
-    if not spans:
-        return True                                        # criterion does not apply
-    return my_judge(claim=outputs, source=spans[0].outputs)  # model sees ~200 tokens
-```
-
-`{{ trace }}` serializes every span into the prompt, so the model must *locate* the right span before
-judging it. That costs more (a full trace can be 50x the two strings you actually need) and makes span
-selection itself nondeterministic — with two lookups in one trace it may compare against the wrong
-one, and may choose differently on a rerun. Extracting in Python fixes the selection and leaves the
-model only the semantic part.
+`{{ trace }}` instead serializes every span into the prompt and makes the model locate the right span
+before judging it. That costs more — an order of magnitude or two versus the two strings actually
+needed — and makes span *selection* a model judgement: with two lookups in one trace it may compare
+against the wrong one, and may choose differently on a rerun. Extracting in Python fixes the
+selection.
 
 Reach for `{{ trace }}` when the criterion is genuinely *about* the whole trace — tool sequencing,
 retry behaviour, did-it-loop — where there is no single span to extract.

--- a/build-a-scorer/SKILL.md
+++ b/build-a-scorer/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: build-a-judge
+name: build-a-scorer
 description: Help the user go from zero to a shipped MLflow evaluation prototype by understanding their app, generalizing a small set of atomic quality criteria, and implementing each criterion with the cheapest reliable scorer. Use when the user wants help choosing, creating, or iterating MLflow judges/scorers for an agent, RAG app, LLM app, or GenAI workflow.
 allowed-tools: Read, Write, Bash, Grep, Glob
 ---
 
-# build-a-judge
+# build-a-scorer
 
 Help the user get from **zero to shipped evaluation prototype**. Not 100% correctness on the first
 pass — a stable, understandable scorer suite they can run, inspect, and iterate on.
@@ -126,13 +126,27 @@ calls, and whether the task is single-turn or session-level.
 `RetrievalSufficiency` require `RETRIEVER` spans and **hard-raise** otherwise. A `web_search` or DB
 lookup instrumented as `TOOL` does not qualify.
 
-For "grounded in tool output", **prefer a code scorer that extracts the tool output from the trace
-and passes just that to a judge, over handing the whole trace to `make_judge` with `{{ trace }}`.**
-A `{{ trace }}` judge re-reads the entire trace on every row: more tokens, more cost, and more
-nondeterminism, because the model has to locate the relevant span itself before judging it. Pulling
-the span in code is deterministic and free; only the comparison needs a model. Reach for
-`{{ trace }}` when the criterion is genuinely about the shape of the whole trace — tool sequencing,
-retry behaviour — rather than about one span's contents.
+For "grounded in tool output", **prefer a code scorer that extracts the relevant span and passes only
+that to a judge, over handing the whole trace to `make_judge` with `{{ trace }}`:**
+
+```python
+# Preferred — code finds the evidence, the model only compares it.
+@scorer
+def grounded_in_lookup(trace, outputs) -> bool:
+    spans = trace.search_spans(span_type=SpanType.TOOL)   # deterministic, free
+    if not spans:
+        return True                                        # criterion does not apply
+    return my_judge(claim=outputs, source=spans[0].outputs)  # model sees ~200 tokens
+```
+
+`{{ trace }}` serializes every span into the prompt, so the model must *locate* the right span before
+judging it. That costs more (a full trace can be 50x the two strings you actually need) and makes span
+selection itself nondeterministic — with two lookups in one trace it may compare against the wrong
+one, and may choose differently on a rerun. Extracting in Python fixes the selection and leaves the
+model only the semantic part.
+
+Reach for `{{ trace }}` when the criterion is genuinely *about* the whole trace — tool sequencing,
+retry behaviour, did-it-loop — where there is no single span to extract.
 
 If traces do not exist, use `inputs` + optional `outputs`/`expectations` with
 `mlflow.genai.evaluate(data=..., predict_fn=..., scorers=[...])`, and mark trace-only upgrades as

--- a/build-a-scorer/SKILL.md
+++ b/build-a-scorer/SKILL.md
@@ -299,12 +299,11 @@ Only after confirmation. Deliver **one consolidated final message**, not code sp
   Always add: "Once traces and human labels come in, align this judge and validate agreement before
   relying on it for monitoring."
 
-**Judge model.** Set `model=` explicitly — the default is `openai:/gpt-4.1-mini` off Databricks, too
-small to trust. Start mid-tier (`anthropic:/claude-sonnet-4-6`, `openai:/gpt-4.1`, or `databricks`),
-then move up if the judge disagrees with human labels on clear-cut cases, and down only after
-measuring agreement on a labelled sample. Never downgrade a red-line judge (safety, legal) to save
-cents — a code prefilter already keeps its volume low. Verify model names against the provider;
-`agent-evaluation/references/scorers.md` is authoritative for URI formats and keys.
+**Judge model.** Set `model=` explicitly and start mid-tier — `anthropic:/claude-sonnet-4-6`,
+`openai:/gpt-4.1`, or the equivalent tier on your provider. Scale up if the judge disagrees with
+human labels on clear-cut cases; scale down only after measuring agreement on a labelled sample.
+Never downgrade a red-line judge (safety, legal) to save cents — a code prefilter already keeps its
+volume low. `agent-evaluation/references/scorers.md` is authoritative for URI formats and keys.
 
 ### Phase 8: Name the validation plan, then hand off
 

--- a/build-a-scorer/SKILL.md
+++ b/build-a-scorer/SKILL.md
@@ -323,16 +323,35 @@ Only after confirmation. Deliver **one consolidated final message**, not code sp
   Always add: "Once traces and human labels come in, align this judge and validate agreement before
   relying on it for monitoring."
 
-**Judge model selection.** Leave `model=None` unless the user has a reason to override it — MLflow
-picks the managed judge on a Databricks tracking URI, or `openai:/gpt-4.1-mini` otherwise. State the
-default you are relying on so the user can see it, and quote cost at their stated volume.
+**Judge model selection — start mid-tier, then move in whichever direction the data says.**
 
-- Start on a mid-tier model and only downgrade after checking agreement on a labelled sample. A
-  cheaper judge that disagrees with humans is more expensive than no judge.
-- Do not downgrade a judge guarding a red-line criterion (safety, legal, compliance) to save cents —
-  volume is usually low, because the code prefilter gates it.
-- `agent-evaluation/references/scorers.md` → "Model Selection for Scorers" is authoritative for
-  `model=` URIs, defaults, and API-key setup. Point there rather than restating it.
+Set `model=` explicitly on every judge. Do not silently accept the default: with no `model`, MLflow
+uses the managed judge on a Databricks tracking URI but `openai:/gpt-4.1-mini` otherwise — a *small*
+model, and a weaker starting point than you want for a judge you are about to trust.
+
+| Provider | Start here (mid-tier) | Scale up if disagreement is high | Scale down only after measuring agreement |
+|---|---|---|---|
+| Anthropic | `anthropic:/claude-sonnet-4-6` | `anthropic:/claude-opus-4-8` | `anthropic:/claude-haiku-4-5` |
+| OpenAI | `openai:/gpt-4.1` | current frontier model | `openai:/gpt-4.1-mini` |
+| Databricks | `databricks` (managed judge) | `databricks:/<endpoint>` on a stronger model | — |
+
+Mid-tier first because both errors cost, asymmetrically: a judge too weak to track your criterion
+produces disagreement you will debug as if it were an app bug, while a frontier judge on a check a
+mid-tier model handles fine merely costs more. Starting in the middle means the first alignment run
+tells you which way to move.
+
+- **Move up** when a judge disagrees with human labels on cases you consider clear-cut. Change the
+  model before rewriting instructions — a weak judge and a vague criterion look identical in the
+  metrics.
+- **Move down** only after measuring agreement on a labelled sample, and re-measure after the swap.
+  A cheaper judge that disagrees with humans costs more than the one it replaced.
+- **Never downgrade a red-line judge** (safety, legal, compliance) to save cents. Its volume is
+  already low because a code prefilter gates it, so the saving is rounding error against the risk.
+- Quote cost at the user's stated volume, and say which model the number assumes.
+
+`agent-evaluation/references/scorers.md` → "Model Selection for Scorers" is authoritative for URI
+formats, defaults, API keys, and reusing the agent's own LLM. Verify current model names against the
+provider before pasting them into code.
 
 ### Phase 8: Name the validation plan, then hand off
 

--- a/build-a-scorer/SKILL.md
+++ b/build-a-scorer/SKILL.md
@@ -126,20 +126,12 @@ calls, and whether the task is single-turn or session-level.
 `RetrievalSufficiency` require `RETRIEVER` spans and **hard-raise** otherwise. A `web_search` or DB
 lookup instrumented as `TOOL` does not qualify.
 
-For "grounded in tool output", **prefer a code scorer that wraps a judge over a judge that takes
-`{{ trace }}`.** A `@scorer` function receives the `trace`, so it can call
-`trace.search_spans(span_type=SpanType.TOOL)` to pull out the one span holding the evidence, then pass
-just that span's output and the agent's claim to a `make_judge` judge whose instructions take two
-short strings. Code locates the evidence; the model only does the semantic comparison.
-
-`{{ trace }}` instead serializes every span into the prompt and makes the model locate the right span
-before judging it. That costs more — an order of magnitude or two versus the two strings actually
-needed — and makes span *selection* a model judgement: with two lookups in one trace it may compare
-against the wrong one, and may choose differently on a rerun. Extracting in Python fixes the
-selection.
-
-Reach for `{{ trace }}` when the criterion is genuinely *about* the whole trace — tool sequencing,
-retry behaviour, did-it-loop — where there is no single span to extract.
+For "grounded in tool output", **wrap a judge in a code scorer instead of passing `{{ trace }}`.** A
+`@scorer` gets the `trace`, so use `trace.search_spans()` to pull the evidence span and pass only it
+plus the claim to the judge. `{{ trace }}` serializes every span and makes the model find the right
+one — costlier, and span selection becomes nondeterministic when there are several. Use `{{ trace }}`
+only when the criterion is about the whole trace (tool sequencing, retries), with no single span to
+extract.
 
 If traces do not exist, use `inputs` + optional `outputs`/`expectations` with
 `mlflow.genai.evaluate(data=..., predict_fn=..., scorers=[...])`, and mark trace-only upgrades as
@@ -211,22 +203,13 @@ on them, but do not act as though the catalog is empty:
 | `UserFrustration`, `ConversationCompleteness`, `KnowledgeRetention`, `ConversationalSafety`, `ConversationalRoleAdherence` | none (session-level) | multi-turn outcome and conversation quality |
 
 **A built-in is a better starting point than a blank prompt — not a substitute for your standard.**
-Built-ins are LLM judges too: they carry MLflow's generic `instructions` for a generic notion of
-relevance or safety. Prefer them because the scaffolding and data contract are already tested, not
-because "built-in" implies correct for your product. Anywhere your bar differs from the industry
-default, say so and expect to align or replace.
-
-Two consequences worth stating to the user:
-
-- **`Guidelines` is the exception that always applies.** It takes *your* policy text, so there is no
-  imported standard — domain specificity is an argument *for* it, not against.
-- **Alignment cuts across the built-in/bespoke line.** `align(traces=...)` is on `Judge`, so
-  single-turn built-ins (`RelevanceToQuery`, `Safety`, `Correctness`, `PIIDetection`) can be aligned
-  to your labels just like `make_judge`. Session-level built-ins (`UserFrustration`,
-  `ConversationCompleteness`, `KnowledgeRetention`) **raise `NotImplementedError` on `align()`** —
-  they are permanently stuck on MLflow's definition. Use them for a cheap first signal, and flag
-  that they cannot be tuned; if the criterion is important and contested, hand-write it so it can be
-  aligned.
+Built-ins are LLM judges carrying MLflow's generic instructions, so "built-in" does not imply correct
+for your product; prefer them because the scaffolding and data contract are already tested. Two
+consequences: `Guidelines` always applies, since it takes *your* policy text. And alignment cuts
+across the built-in/bespoke line — `align()` is on `Judge`, so single-turn built-ins can be aligned to
+your labels like `make_judge`, but session-level ones (`UserFrustration`, `ConversationCompleteness`,
+`KnowledgeRetention`) **raise `NotImplementedError`** and are stuck on MLflow's definition. Hand-write
+a criterion that is important and contested, so it can be aligned.
 
 Skipping built-ins is legitimate when your standard genuinely differs. Skipping them without
 looking is not.
@@ -316,35 +299,12 @@ Only after confirmation. Deliver **one consolidated final message**, not code sp
   Always add: "Once traces and human labels come in, align this judge and validate agreement before
   relying on it for monitoring."
 
-**Judge model selection — start mid-tier, then move in whichever direction the data says.**
-
-Set `model=` explicitly on every judge. Do not silently accept the default: with no `model`, MLflow
-uses the managed judge on a Databricks tracking URI but `openai:/gpt-4.1-mini` otherwise — a *small*
-model, and a weaker starting point than you want for a judge you are about to trust.
-
-| Provider | Start here (mid-tier) | Scale up if disagreement is high | Scale down only after measuring agreement |
-|---|---|---|---|
-| Anthropic | `anthropic:/claude-sonnet-4-6` | `anthropic:/claude-opus-4-8` | `anthropic:/claude-haiku-4-5` |
-| OpenAI | `openai:/gpt-4.1` | current frontier model | `openai:/gpt-4.1-mini` |
-| Databricks | `databricks` (managed judge) | `databricks:/<endpoint>` on a stronger model | — |
-
-Mid-tier first because both errors cost, asymmetrically: a judge too weak to track your criterion
-produces disagreement you will debug as if it were an app bug, while a frontier judge on a check a
-mid-tier model handles fine merely costs more. Starting in the middle means the first alignment run
-tells you which way to move.
-
-- **Move up** when a judge disagrees with human labels on cases you consider clear-cut. Change the
-  model before rewriting instructions — a weak judge and a vague criterion look identical in the
-  metrics.
-- **Move down** only after measuring agreement on a labelled sample, and re-measure after the swap.
-  A cheaper judge that disagrees with humans costs more than the one it replaced.
-- **Never downgrade a red-line judge** (safety, legal, compliance) to save cents. Its volume is
-  already low because a code prefilter gates it, so the saving is rounding error against the risk.
-- Quote cost at the user's stated volume, and say which model the number assumes.
-
-`agent-evaluation/references/scorers.md` → "Model Selection for Scorers" is authoritative for URI
-formats, defaults, API keys, and reusing the agent's own LLM. Verify current model names against the
-provider before pasting them into code.
+**Judge model.** Set `model=` explicitly — the default is `openai:/gpt-4.1-mini` off Databricks, too
+small to trust. Start mid-tier (`anthropic:/claude-sonnet-4-6`, `openai:/gpt-4.1`, or `databricks`),
+then move up if the judge disagrees with human labels on clear-cut cases, and down only after
+measuring agreement on a labelled sample. Never downgrade a red-line judge (safety, legal) to save
+cents — a code prefilter already keeps its volume low. Verify model names against the provider;
+`agent-evaluation/references/scorers.md` is authoritative for URI formats and keys.
 
 ### Phase 8: Name the validation plan, then hand off
 


### PR DESCRIPTION
## What

Adds `build-a-judge`, an opinionated skill for users to use when building a judge.

There is some overlap with `agent-evaluation` on the building judges part, but this is a specialized and standalone skill. 

| Skill | Owns |
|---|---|
| `build-a-judge` | Elicit and sharpen criteria → atomicity → rule + outcome coverage → route each to code check / built-in / LLM judge → emit the implementation → name the validation plan |
| `agent-evaluation` | Register scorers → dataset discovery/creation → dry run → evaluate → analyze |

I've broken apart both skills and got `agent-evaluation` to reference `build-a-judge` instead.

## Why a separate skill

Starting from zero is really hard, and there are nuances about evaluation that people new to agentic development are not familiar with. We should guide new users along a golden path as much as possible. 

Also in general, agents stop following instructions once a skill gets too long, so a standalone skill might help with adherence to guidelines. 

I have listed down some opinions, of which some are new. 

| Position | Because |
|---|---|
| 3-5 scorers, hard cap | unvalidated checks are worse than none |
| One scorer, one criterion | compound "overall quality" judges can't be debugged when they fail |
| Code check → built-in → LLM judge, with a required justification per judge | LLM-judge-by-default is expensive and unaligned |
| Outcome checks, not only policy checks | an agent can pass every compliance check and still fail everyone who used it |
| The first LLM judge is a draft | it needs alignment against real labels before you trust it |
| Talk before code | a wall of implementation ends the design conversation |

I want judge creation to be a conversation between user and LLM. The Skill needs to distill the user notion of right and wrong into a small set of judges which they can iterate on. It doesn't have to be perfect, just good enough to start work on. 


## Testing

Testing was done manually. I passed in a starting scenario into an agent, and had the agent invoke this skill and store the transcript. I then inspected the transcript to see if I agreed with the scorer suite and iterated until a satisfactory outcome was reached. 

## Future Extensions

For future extensions, I think we can consider outsourcing this flow into the UI, or via Assistant for a lower lift approach and for better interaction with the eval user flow. But this is comparatively less important. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)
