### PR TITLE
Steer agents to debug from traces after tracing is set up

### DIFF
--- a/fix-agent-issue/SKILL.md
+++ b/fix-agent-issue/SKILL.md
@@ -13,7 +13,10 @@ description: >-
   "improve my agent based on this trace", "make the agent do X instead of Y", "I
   want the agent to lead with/prioritize/recommend X", "new business rule: the
   agent should X", "always/never do X", "change the agent's default behavior" — or
-  shares a trace they want addressed.
+  when you are debugging an agent's behavior mid-loop and reaching for source code
+  and output files — "debug this agent", "figure out why the agent did X", "the
+  agent's output is wrong", "why did the agent produce this" — where the trace is
+  the evidence to read first — or shares a trace they want addressed.
 ---
 
 # Fix Agent Issue

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -124,3 +124,11 @@ See `references/distributed-tracing.md` for:
 ### Databricks (Unity Catalog storage)
 
 See `references/databricks.md` for storing traces in Unity Catalog Delta tables by binding an experiment to a `UnityCatalog` trace location (catalog, schema, table prefix).
+
+---
+
+## Next: debug from the traces you just captured
+
+Tracing is now in place. When you move on to debug or improve the agent's behavior, read the spans first. Do not fall back to reading source code and output files alone. The trace shows what each step actually received, produced, and decided, which is the evidence source that pins down where behavior went wrong.
+
+Load the `fix-agent-issue` skill for this. It grounds the diagnosis in the trace, what the agent did, what it should have done, and why, before any code change, and codifies the fix as a regression test so it sticks. Reach for it as soon as you start asking why the agent produced a given output, not only when someone explicitly reports a bug.


### PR DESCRIPTION
## What

Add a handoff so that an agent which has just set up MLflow tracing is steered to debug from the traces, and widen the `fix-agent-issue` triggers so it fires during a general debug loop, not only on an explicit bug report.

- `instrumenting-with-mlflow-tracing/SKILL.md`: append a short "Next: debug from the traces you just captured" section pointing at `fix-agent-issue` for span-first diagnosis.
- `fix-agent-issue/SKILL.md`: extend the `description` triggers with debug-loop phrases ("debug this agent", "figure out why the agent did X", "the agent's output is wrong", "why did the agent produce this").

## Why

Observed in a hands-on session: an agent set up tracing correctly, then debugged the app's behavior by reading source code and output files without opening a single trace, and shipped a correct-but-incomplete fix. It read the spans only after being challenged, which is when it caught a ranking bug it had missed.

Two gaps in the current skills let that happen:

1. `instrumenting-with-mlflow-tracing` ends at verification. Nothing hands off to trace-first debugging once tracing works, so the agent never learns to use what it just captured.
2. `fix-agent-issue` already leads with span-driven diagnosis, but its `description` triggers require an explicit "fix/change the agent" ask ("this answer is wrong", "make the agent do X"). An agent silently debugging its own output mid-loop matches none of them, so the skill never loads at the moment it would help.

This change closes both: the setup skill points forward to debugging, and `fix-agent-issue` now recognizes an in-progress debug loop as a trigger.

## Testing

No unit-test harness applies. these are skill-instruction (markdown) changes. Verified structurally: the YAML frontmatter still parses and the `description` remains a single string.
