### PR TITLE
Clarify safe threaded tracing scope

### DIFF
--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -37,6 +37,12 @@ If unclear, check for `package.json` (TypeScript) or `requirements.txt`/`pyproje
 - Logging or metric emission
 - Pure utility functions (math, sorting, filtering)
 
+### Decide the trace boundary before adding a decorator
+
+Before adding a manual `@mlflow.trace`, classify the operation. Do not decorate per-item validation, parsing, formatting, or utility helpers because they call an external service. Keep high-cardinality details on the existing workflow span. Return aggregate counts and a bounded failure list in that span's output.
+
+With framework autologging enabled, inspect one trace before adding manual decorators. Add manual spans only for high-value operations that autologging misses. For `ThreadPoolExecutor` work, leave utilities untraced. Propagate context only for a child operation worth inspecting.
+
 **Rule of thumb**: Trace operations that are important for debugging and identifying issues in your application.
 
 ---
@@ -70,7 +76,9 @@ for span in spans:
     print(f"  - {span.name} ({span.span_type})")
 ```
 
-4. **Report the result** — tell the user how many traces and spans were found and confirm tracing is working
+4. **Verify the expected trace topology** — state how many application root traces this test run should create, normally one. Inspect every trace returned for the run. A standalone worker or helper trace is a failed verification.
+
+5. **Report the result** — report trace count, topology, and expected span coverage.
 
 ### If no traces appear
 

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -39,7 +39,7 @@ If unclear, check for `package.json` (TypeScript) or `requirements.txt`/`pyproje
 
 ### Decide the trace boundary before adding a decorator
 
-Before adding a manual `@mlflow.trace`, classify the operation. Do not decorate per-item validation, parsing, formatting, or utility helpers because they call an external service. Keep high-cardinality details on the existing workflow span. Return aggregate counts and a bounded failure list in that span's output.
+Before adding a manual `@mlflow.trace`, classify the operation. Do not decorate per-item validation, parsing, formatting, or utility helpers solely because they call an external service. Trace an external service call when it is a high-value operation worth diagnosing; otherwise, keep high-cardinality details on the existing workflow span. Return aggregate counts and a bounded failure list in that span's output.
 
 With framework autologging enabled, inspect one trace before adding manual decorators. Add manual spans only for high-value operations that autologging misses. For `ThreadPoolExecutor` work, leave utilities untraced. Propagate context only for a child operation worth inspecting.
 
@@ -54,26 +54,52 @@ After instrumenting the code, **always verify that tracing is working**.
 > **Planning to evaluate your agent?** Tracing must be working before you run `agent-evaluation`. Complete verification below first.
 
 
-1. **Run the instrumented code** — execute the application or agent so that at least one traced operation fires
-2. **Confirm traces are logged** — use `mlflow.search_traces()` or `MlflowClient().search_traces()` to check that traces appear in the experiment. If the trace is not found, try `mlflow.flush_trace_async_logging()` to flush the background queue.
+1. **Run the instrumented invocation in a new MLflow run** — execute the application or agent so that at least one traced operation fires. Record the run ID and the timestamp immediately before the invocation.
+2. **Confirm invocation-scoped traces and topology** — search only the traces from this invocation, not the whole experiment. If the trace is not found, try `mlflow.flush_trace_async_logging()` to flush the background queue.
+3. **Verify spans were captured** — confirm every invocation-scoped trace contains the expected spans and topology, not just an empty shell.
 
 ```python
+import time
 import mlflow
 
+expected_root_trace_count = 1
+expected_root_span_name = "<root_operation>"
+expected_span_names = {"<root_operation>", "<high_value_child_operation>"}
+
+run_start_ms = int(time.time() * 1000)
+with mlflow.start_run() as run:
+    run_instrumented_application()
+
 mlflow.flush_trace_async_logging()
-traces = mlflow.search_traces(experiment_ids=["<experiment_id>"])
+traces = mlflow.search_traces(
+    experiment_ids=["<experiment_id>"],
+    run_id=run.info.run_id,
+    filter_string=f"trace.timestamp_ms > {run_start_ms}",
+    return_type="list",
+)
 print(f"Found {len(traces)} trace(s)")
-assert len(traces) > 0, "No traces were logged — check tracking URI and experiment settings"
-```
+assert len(traces) == expected_root_trace_count, (
+    f"Expected {expected_root_trace_count} root trace(s), found {len(traces)}"
+)
 
-3. **Verify spans were captured** — confirm the trace contains the expected spans, not just an empty shell:
-
-```python
-trace = traces.iloc[0]
-spans = mlflow.get_trace(trace.trace_id).data.spans
-print(f"Trace has {len(spans)} span(s)")
-for span in spans:
-    print(f"  - {span.name} ({span.span_type})")
+for trace in traces:
+    spans = trace.data.spans
+    root_spans = [span for span in spans if span.parent_id is None]
+    assert len(root_spans) == 1, (
+        f"Trace {trace.info.trace_id} has {len(root_spans)} root spans"
+    )
+    assert root_spans[0].name == expected_root_span_name, (
+        f"Trace {trace.info.trace_id} has unexpected root {root_spans[0].name!r}; "
+        "a worker or helper must not become a standalone trace"
+    )
+    span_names = {span.name for span in spans}
+    assert expected_span_names <= span_names, (
+        f"Trace {trace.info.trace_id} is missing expected spans: "
+        f"{expected_span_names - span_names}"
+    )
+    print(f"Trace {trace.info.trace_id} has {len(spans)} span(s)")
+    for span in spans:
+        print(f"  - {span.name} ({span.span_type})")
 ```
 
 4. **Verify the expected trace topology** — state how many application root traces this test run should create, normally one. Inspect every trace returned for the run. A standalone worker or helper trace is a failed verification.

--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -74,7 +74,7 @@ mlflow.flush_trace_async_logging()
 traces = mlflow.search_traces(
     experiment_ids=["<experiment_id>"],
     run_id=run.info.run_id,
-    filter_string=f"trace.timestamp_ms > {run_start_ms}",
+    filter_string=f"trace.timestamp_ms >= {run_start_ms}",
     return_type="list",
 )
 print(f"Found {len(traces)} trace(s)")

--- a/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
+++ b/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
@@ -56,13 +56,17 @@ def process_items(items: list) -> list:
             return result
 
     with ThreadPoolExecutor(max_workers=4) as executor:
-        # Copy context to each thread
-        ctx = contextvars.copy_context()
-        futures = [executor.submit(ctx.run, process_one, item) for item in items]
-        results = [f.result() for f in futures]
+        futures = []
+        for item in items:
+            # Copy once per submission: a Context cannot run concurrently.
+            ctx = contextvars.copy_context()
+            futures.append(executor.submit(ctx.run, process_one, item))
+        results = [future.result() for future in futures]
 
     return results
 ```
+
+Create a fresh context for each submitted task. Reusing one `Context` concurrently raises `RuntimeError: cannot enter context ... is already entered`.
 
 **Using `run_in_executor` with asyncio**:
 

--- a/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
+++ b/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
@@ -45,15 +45,9 @@ from concurrent.futures import ThreadPoolExecutor
 import contextvars
 
 @mlflow.trace(name="parallel_processing", span_type=SpanType.CHAIN)
-def process_items(items: list) -> list:
-    results = []
-
+def process_items(items: list) -> dict:
     def process_one(item):
-        with mlflow.start_span(name=f"process_{item}") as span:
-            span.set_inputs({"item": item})
-            result = heavy_computation(item)
-            span.set_outputs({"result": result})
-            return result
+        return heavy_computation(item)
 
     with ThreadPoolExecutor(max_workers=4) as executor:
         futures = []
@@ -61,12 +55,27 @@ def process_items(items: list) -> list:
             # Copy once per submission: a Context cannot run concurrently.
             ctx = contextvars.copy_context()
             futures.append(executor.submit(ctx.run, process_one, item))
-        results = [future.result() for future in futures]
+        results, failure_types = [], []
+        for future in futures:
+            try:
+                results.append(future.result())
+            except Exception as exc:
+                failure_types.append(type(exc).__name__)
 
-    return results
+    return {
+        "results": results,
+        "summary": {
+            "processed_count": len(items),
+            "succeeded_count": len(results),
+            "failed_count": len(failure_types),
+            "failures": failure_types[:10],
+        },
+    }
 ```
 
 Create a fresh context for each submitted task. Reusing one `Context` concurrently raises `RuntimeError: cannot enter context ... is already entered`.
+
+`process_one` deliberately creates no per-item span. When worker outcomes include validation, return aggregate counts and a bounded, redacted failure list in `parallel_processing`'s output, as shown. Do not create a span or call `set_inputs`/`set_outputs` for each item.
 
 **Using `run_in_executor` with asyncio**:
 

--- a/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
+++ b/instrumenting-with-mlflow-tracing/references/advanced-patterns.md
@@ -55,27 +55,25 @@ def process_items(items: list) -> dict:
             # Copy once per submission: a Context cannot run concurrently.
             ctx = contextvars.copy_context()
             futures.append(executor.submit(ctx.run, process_one, item))
-        results, failure_types = [], []
+        succeeded_count, redacted_failures = 0, []
         for future in futures:
             try:
-                results.append(future.result())
+                future.result()
+                succeeded_count += 1
             except Exception as exc:
-                failure_types.append(type(exc).__name__)
+                redacted_failures.append({"error_type": type(exc).__name__})
 
     return {
-        "results": results,
-        "summary": {
-            "processed_count": len(items),
-            "succeeded_count": len(results),
-            "failed_count": len(failure_types),
-            "failures": failure_types[:10],
-        },
+        "processed_count": len(items),
+        "succeeded_count": succeeded_count,
+        "failed_count": len(redacted_failures),
+        "failures": redacted_failures[:10],
     }
 ```
 
 Create a fresh context for each submitted task. Reusing one `Context` concurrently raises `RuntimeError: cannot enter context ... is already entered`.
 
-`process_one` deliberately creates no per-item span. When worker outcomes include validation, return aggregate counts and a bounded, redacted failure list in `parallel_processing`'s output, as shown. Do not create a span or call `set_inputs`/`set_outputs` for each item.
+`process_one` deliberately creates no per-item span. `parallel_processing` returns only aggregate counts and a bounded, redacted failure list; it does not return worker results or raw item values in the traced output. Do not create a span or call `set_inputs`/`set_outputs` for each item.
 
 **Using `run_in_executor` with asyncio**:
 


### PR DESCRIPTION
## Summary

Clarifies when coding agents should leave high-cardinality helper operations untraced. Requires verification of the expected root-trace topology. Fixes the concurrent thread-context example by copying context per submitted task.

## Verification

- Reproduced the failure from concurrently reusing one `contextvars.Context`.
- Verified a fresh context per executor submission.
- Ran structural Markdown checks and `git diff --check`.
