### PR TITLE
instrumenting-with-mlflow-tracing: Databricks setup guidance (experiment path, auth pre-flight, current search_traces param)

### DIFF
--- a/instrumenting-with-mlflow-tracing/SKILL.md
+++ b/instrumenting-with-mlflow-tracing/SKILL.md
@@ -16,6 +16,17 @@ If unclear, check for `package.json` (TypeScript) or `requirements.txt`/`pyproje
 
 ---
 
+## Databricks: verify auth before the first run
+
+When the target is a Databricks workspace, confirm auth and the target workspace before running instrumented code. An expired token, or a default profile pointed at the wrong workspace, drops traces silently at export with no error raised.
+
+```bash
+databricks auth token --profile <name>   # fails if the token is expired. Re-run: databricks auth login --profile <name>
+python -c "import mlflow; print(mlflow.get_tracking_uri())"   # confirm it targets the intended workspace
+```
+
+---
+
 ## What to Trace
 
 **Trace these operations** (high debugging/observability value):
@@ -55,7 +66,7 @@ After instrumenting the code, **always verify that tracing is working**.
 import mlflow
 
 mlflow.flush_trace_async_logging()
-traces = mlflow.search_traces(experiment_ids=["<experiment_id>"])
+traces = mlflow.search_traces(locations=["<experiment_id>"])
 print(f"Found {len(traces)} trace(s)")
 assert len(traces) > 0, "No traces were logged — check tracking URI and experiment settings"
 ```

--- a/instrumenting-with-mlflow-tracing/references/databricks.md
+++ b/instrumenting-with-mlflow-tracing/references/databricks.md
@@ -23,6 +23,7 @@ mlflow.set_experiment(
 **`table_prefix`** is the prefix applied to every table storing trace data. MLflow creates four Delta tables from it: `<table_prefix>_otel_spans`, `<table_prefix>_otel_logs`, `<table_prefix>_otel_metrics`, and `<table_prefix>_otel_annotations`.
 
 **Notes**:
+- Experiment names on Databricks must be absolute workspace paths (`/Users/<email>/name` or `/Shared/name`). A bare name is rejected. To attach to an existing experiment, use `mlflow.set_experiment(experiment_id="<numeric-id>")`.
 - Requires a SQL warehouse (`MLFLOW_TRACING_SQL_WAREHOUSE_ID`) to provision and query the tables.
 - A UC trace location is permanent — once bound, an experiment cannot be reassigned to a different UC location.
 - To create the experiment explicitly, use `mlflow.create_experiment(name=..., trace_location=UnityCatalog(...))`, then `mlflow.set_experiment(experiment_id=...)`.

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -28,6 +28,11 @@ mlflow.set_tracking_uri("http://localhost:5000")  # skip if MLFLOW_TRACKING_URI 
 mlflow.set_experiment("my-agent")                 # skip if MLFLOW_EXPERIMENT_ID is set
 ```
 
+> **On Databricks: the experiment name must be an absolute workspace path.**
+> `mlflow.set_experiment("my-agent")` is rejected or lands in the wrong place. Use
+> `mlflow.set_experiment("/Users/<your-email>/my-agent")` or, to attach to an existing
+> experiment, look up its numeric ID in the UI and pass `set_experiment(experiment_id="<id>")`.
+
 ### Enable Tracing
 
 **For supported frameworks** (LangChain, LangGraph, OpenAI, etc.):


### PR DESCRIPTION
## What

Add Databricks setup guidance to `instrumenting-with-mlflow-tracing` and refresh one verification snippet.

- `references/python.md`: after the Quick Start `set_experiment("my-agent")` line, add a callout that on Databricks the experiment name must be an absolute workspace path (`/Users/<email>/name` or `/Shared/name`), and that `set_experiment(experiment_id="<id>")` attaches to an existing experiment.
- `references/databricks.md`: add the same absolute-path note to the Notes block.
- `SKILL.md`: add a short "Databricks: verify auth before the first run" section (check the CLI profile token and the tracking URI target before the first instrumented run).
- `SKILL.md`: change the verification snippet from the deprecated `search_traces(experiment_ids=...)` to the current `search_traces(locations=...)`.

## Why

Observed in a hands-on session: a coding agent instrumenting a LangGraph app against a Databricks workspace hit two setup gaps the skill did not cover.

1. It wrote `mlflow.set_experiment("brief-agent")` from the Quick Start form. On Databricks a bare name is rejected, so the first run exited 1. The skill's Python guide showed the bare form with no Databricks callout.
2. The default CLI profile pointed at a different workspace and its token had expired, so traces silently failed to export while the app kept running. The skill's only auth guidance was a post-failure diagnostic, not a before-first-run check.

The `search_traces(experiment_ids=...)` change is a small correctness fix: that parameter is deprecated in favor of `locations` in the current MLflow source (`mlflow/tracing/fluent.py`, `@deprecated_parameter("experiment_ids", "locations")`).

This does not overlap the open UC-trace-storage callout in #33, which adds a note about the 100k trace cap and binding a UC trace location. It touches neither the experiment-name path format nor the auth pre-flight.

## Testing

No unit-test harness applies. These are skill-instruction (markdown) changes. Verified that `locations` is the current `search_traces` parameter against MLflow master, and that the YAML frontmatter still parses.
