### PR TITLE
instrumenting-with-mlflow-tracing: prefer one framework autolog call over redundant decorators

### DIFF
--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -132,7 +132,7 @@ echo "MLFLOW_EXPERIMENT_ID=$MLFLOW_EXPERIMENT_ID"
 1. **Install MLflow** (version >=3.8.0)
 2. **Configure environment** (tracking URI and experiment)
    - **Guide**: Follow `references/setup-guide.md` Steps 1-2
-3. **Integrate tracing** (autolog and @mlflow.trace decorators)
+3. **Integrate tracing** (autolog for supported frameworks, or @mlflow.trace for custom code)
    - ⚠️ **MANDATORY**: Use the `instrumenting-with-mlflow-tracing` skill for tracing setup
    - ✓ **VERIFY**: Run `scripts/validate_tracing_runtime.py` after implementing
 
@@ -142,7 +142,7 @@ echo "MLFLOW_EXPERIMENT_ID=$MLFLOW_EXPERIMENT_ID"
 
 - [ ] MLflow >=3.8.0 installed
 - [ ] MLFLOW_TRACKING_URI and MLFLOW_EXPERIMENT_ID set
-- [ ] Autolog enabled and @mlflow.trace decorators added
+- [ ] Autolog enabled for supported frameworks, or @mlflow.trace added for custom code (do not add both to the same framework operations)
 - [ ] Test run creates a trace (verify trace ID is not None)
 
 **Validation scripts:**

--- a/agent-evaluation/SKILL.md
+++ b/agent-evaluation/SKILL.md
@@ -132,7 +132,7 @@ echo "MLFLOW_EXPERIMENT_ID=$MLFLOW_EXPERIMENT_ID"
 1. **Install MLflow** (version >=3.8.0)
 2. **Configure environment** (tracking URI and experiment)
    - **Guide**: Follow `references/setup-guide.md` Steps 1-2
-3. **Integrate tracing** (autolog for supported frameworks, or @mlflow.trace for custom code)
+3. **Integrate tracing** (autolog and @mlflow.trace decorators)
    - ⚠️ **MANDATORY**: Use the `instrumenting-with-mlflow-tracing` skill for tracing setup
    - ✓ **VERIFY**: Run `scripts/validate_tracing_runtime.py` after implementing
 
@@ -142,7 +142,7 @@ echo "MLFLOW_EXPERIMENT_ID=$MLFLOW_EXPERIMENT_ID"
 
 - [ ] MLflow >=3.8.0 installed
 - [ ] MLFLOW_TRACKING_URI and MLFLOW_EXPERIMENT_ID set
-- [ ] Autolog enabled for supported frameworks, or @mlflow.trace added for custom code (do not add both to the same framework operations)
+- [ ] Autolog enabled and @mlflow.trace decorators added
 - [ ] Test run creates a trace (verify trace ID is not None)
 
 **Validation scripts:**

--- a/instrumenting-with-mlflow-tracing/references/python.md
+++ b/instrumenting-with-mlflow-tracing/references/python.md
@@ -69,6 +69,8 @@ mlflow.autogen.autolog()      # AutoGen
 mlflow.crewai.autolog()       # CrewAI
 ```
 
+**Start with one autolog call. Do not decorate framework operations to recreate automatic spans.** `mlflow.langchain.autolog()` captures LangGraph graph execution, nodes, tools, and model calls on its own. Adding `@mlflow.trace` to those same nodes, tools, or model calls produces duplicate spans. Add a manual span only for app-specific work that the framework does not capture, such as a retrieval step you wrote or an outer application boundary (see "Combining AutoLogging with Custom Tracing" below).
+
 ### Method 2: Decorator (Recommended for Custom Code)
 
 **Prefer decorator over manual spans** - it auto-captures function name, inputs, and outputs.
@@ -155,6 +157,8 @@ traces = mlflow.search_traces(
 ---
 
 ## Combining AutoLogging with Custom Tracing
+
+The `@mlflow.trace` decorator here marks a deliberate application boundary that wraps a custom retrieval step and the autologged LLM call under one root span. It does not re-decorate the framework's own nodes or model calls, which autolog already captures.
 
 ```python
 import mlflow

--- a/tests/configs/langgraph_autolog_guidance.yaml
+++ b/tests/configs/langgraph_autolog_guidance.yaml
@@ -1,0 +1,24 @@
+name: "langgraph-autolog-guidance"
+project_dir: langgraph-agent
+
+setup_script: tests/scripts/setup_langgraph_autolog_guidance.py
+judges:
+  - tests/judges/tracing_skill_invoked.py
+  - tests/judges/agent_ran_code.py
+  - tests/judges/langgraph_autolog_guidance.py
+
+skills:
+  - instrumenting-with-mlflow-tracing
+
+prompt: "Add MLflow tracing to the LangGraph agent in agent.py, then run it to verify a trace is logged. Do not ask for input."
+timeout_seconds: 900
+allowed_tools: "Bash,Read,Write,Edit,Grep,Glob,WebFetch"
+
+mlflow_port: 32941
+tracking_uri: null
+
+test_runs_dir: /tmp
+keep_workdir: true
+
+environment:
+  OPENAI_API_KEY: ""

--- a/tests/judges/langgraph_autolog_guidance.py
+++ b/tests/judges/langgraph_autolog_guidance.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from mlflow.genai.judges import make_judge
+
+
+def get_judges() -> list:
+    return [
+        make_judge(
+            name="langgraph-autolog-first",
+            instructions=(
+                "Inspect the agent's work in the {{ trace }} to judge how it added MLflow "
+                "tracing to the LangGraph agent in agent.py.\n\n"
+                "Answer 'yes' only if BOTH conditions hold:\n"
+                "1. The agent enabled framework tracing with a single mlflow.langchain.autolog() "
+                "call (autolog covers LangGraph graph execution, nodes, tools, and model calls).\n"
+                "2. The agent did NOT add @mlflow.trace decorators or mlflow.start_span() calls to "
+                "the graph, its nodes (call_model, call_tool), the tool function, or the model call "
+                "for the sole purpose of recreating spans that autolog already produces.\n\n"
+                "It is still 'yes' if the agent added a single deliberate application-boundary "
+                "decorator or manual span around app-specific work that LangGraph does not capture "
+                "on its own (for example a top-level run() wrapper, or a span around a custom "
+                "retrieval or post-processing step it wrote). That is allowed and expected.\n\n"
+                "Answer 'no' if the agent decorated LangGraph nodes, the tool, or the model call "
+                "with @mlflow.trace in addition to autolog, which produces duplicate spans, or if "
+                "it never enabled autolog for the framework."
+            ),
+            feedback_value_type=Literal["yes", "no"],
+        ),
+    ]

--- a/tests/scripts/setup_langgraph_autolog_guidance.py
+++ b/tests/scripts/setup_langgraph_autolog_guidance.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Scaffold a minimal, untraced LangGraph agent for the autolog-guidance fixture.
+
+The agent under test must add MLflow tracing to this app. The judge then checks
+that it used a single framework autolog call and did not decorate LangGraph
+nodes, tools, or model calls purely to recreate spans autolog already produces.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+AGENT_SOURCE = '''\
+from typing import Annotated, TypedDict
+
+from langchain_core.messages import HumanMessage
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+def lookup_weather(city: str) -> str:
+    """A trivial tool the graph can call."""
+    return f"It is 72F and sunny in {city}."
+
+
+def call_model(state: State) -> State:
+    llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
+    response = llm.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+def call_tool(state: State) -> State:
+    reading = lookup_weather("San Francisco")
+    return {"messages": [HumanMessage(content=reading)]}
+
+
+def build_graph():
+    graph = StateGraph(State)
+    graph.add_node("model", call_model)
+    graph.add_node("tool", call_tool)
+    graph.set_entry_point("tool")
+    graph.add_edge("tool", "model")
+    graph.add_edge("model", END)
+    return graph.compile()
+
+
+def run(question: str) -> str:
+    app = build_graph()
+    result = app.invoke({"messages": [HumanMessage(content=question)]})
+    return result["messages"][-1].content
+
+
+if __name__ == "__main__":
+    print(run("What is the weather in San Francisco?"))
+'''
+
+REQUIREMENTS = "\n".join(
+    [
+        "mlflow>=3.8.0",
+        "langgraph",
+        "langchain-openai",
+        "langchain-core",
+    ]
+)
+
+
+def main() -> None:
+    project_dir = Path(os.environ["PROJECT_DIR"])
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / "agent.py").write_text(AGENT_SOURCE, encoding="utf-8")
+    (project_dir / "requirements.txt").write_text(REQUIREMENTS + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Make the autolog-first rule for supported frameworks explicit, so a coding agent
does not add `@mlflow.trace` decorators on top of `mlflow.langchain.autolog()` and
produce duplicate spans.

- `instrumenting-with-mlflow-tracing/references/python.md`: add a rule under the
  framework AutoLogging method. One `mlflow.langchain.autolog()` call captures
  LangGraph graph execution, nodes, tools, and model calls. Decorating those same
  operations only recreates spans autolog already emits. Label the existing
  "Combining AutoLogging with Custom Tracing" example's decorator as a deliberate
  application boundary, not a re-decoration of framework operations.
- `agent-evaluation/SKILL.md`: replace the "autolog and `@mlflow.trace` decorators"
  requirement with the either/or rule (autolog for frameworks, decorators for custom
  code), and update the matching checklist item.

## Why

Agents instrumenting a LangGraph app sometimes enable autolog and also decorate the
graph nodes and model calls, which duplicates every framework span. The duplicates
only disappear after the decorators are removed. The guidance now states the rule up
front while preserving the intentional manual-span cases: an outer application
boundary, and a manual child span around app-specific work the framework does not
capture.

## Test

Adds `tests/configs/langgraph_autolog_guidance.yaml` with a setup script that
scaffolds a minimal untraced LangGraph agent and a judge
(`tests/judges/langgraph_autolog_guidance.py`) that passes only when the agent used a
single framework autolog call and did not decorate LangGraph nodes, tools, or model
calls purely for coverage, while still allowing a deliberate application-boundary span.

Run with `python tests/test_skill.py tests/configs/langgraph_autolog_guidance.yaml`.
